### PR TITLE
Add node deadline estimation for L2 to L1 messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://offchainlabs.com",
   "scripts": {
-    "audit:ci": "audit-ci -l -a 1006805 1006806 1006865 1006896 1006899",
+    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486",
     "postinstall": "node ./scripts/genAbi.js",
     "gen:abi": "node ./scripts/genAbi.js",
     "prepublishOnly": "yarn build && yarn format",

--- a/src/lib/message/L2ToL1Message.ts
+++ b/src/lib/message/L2ToL1Message.ts
@@ -317,8 +317,7 @@ export class L2ToL1MessageReader extends L2ToL1Message {
   }
 
   /**
-   * Estimates the L1 block number in which a particular L2 to L1 tx will be
-   * available for execution
+   * Estimates the L1 block number in which this L2 to L1 tx will be available for execution
    * @param l2Provider
    * @returns expected L1 block number where the L2 to L1 message will be executable
    */

--- a/src/lib/message/L2ToL1Message.ts
+++ b/src/lib/message/L2ToL1Message.ts
@@ -320,7 +320,6 @@ export class L2ToL1MessageReader extends L2ToL1Message {
   public async getExpectedNodeDeadline(
     l2Provider: Provider
   ): Promise<BigNumber> {
-    // this.indexInBatch
     const outbox = Outbox__factory.connect(this.outboxAddress, this.l1Provider)
 
     const network = l2Networks[(await l2Provider.getNetwork()).chainId]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,9 +3201,9 @@ map-stream@0.0.7:
   integrity sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=
 
 marked@^4.0.10:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
-  integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.13.tgz#4fd46ca93da46448f3d83f054d938c4f905a258d"
+  integrity sha512-lS/ZCa4X0gsRcfWs1eoh6dLnHr9kVH3K1t2X4M/tTtNouhZ7anS1Csb6464VGLQHv8b2Tw1cLeZQs58Jav8Rzw==
 
 mcl-wasm@^0.7.1:
   version "0.7.9"
@@ -3294,9 +3294,9 @@ minimatch@^3.0.0, minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Added a utility method to calculate node deadline following the implementation from the [token bridge]( https://github.com/OffchainLabs/arb-token-bridge/blob/02817aff63b87f7a6dabe5fa4f6457fc024460a9/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts#L1052) and substituting [subgraphs](https://github.com/OffchainLabs/arbitrum-subgraphs/blob/e6be72526329c5a8e04b39393a258e39c5c49363/packages/arb-bridge-eth/src/mapping.ts#L200-L210) for event queries