### PR TITLE
fix: default l2 gas buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/src/lib/message/L1ToL2MessageGasEstimator.ts
+++ b/src/lib/message/L1ToL2MessageGasEstimator.ts
@@ -11,6 +11,7 @@ import { constants } from 'ethers'
 import { utils } from 'ethers'
 
 const DEFAULT_SUBMISSION_PRICE_PERCENT_INCREASE = BigNumber.from(340)
+const DEFAULT_MAX_GAS_PERCENT_INCREASE = BigNumber.from(50)
 
 /**
  * An optional big number percentage increase
@@ -41,7 +42,7 @@ export interface GasOverrides {
 
 const defaultL1ToL2MessageEstimateOptions = {
   maxSubmissionFeePercentIncrease: DEFAULT_SUBMISSION_PRICE_PERCENT_INCREASE,
-  maxGasPercentIncrease: constants.Zero,
+  maxGasPercentIncrease: DEFAULT_MAX_GAS_PERCENT_INCREASE,
   maxGasPricePercentIncrease: constants.Zero,
   sendL2CallValueFromL1: true,
 }

--- a/src/lib/message/L1ToL2MessageGasEstimator.ts
+++ b/src/lib/message/L1ToL2MessageGasEstimator.ts
@@ -11,6 +11,7 @@ import { constants } from 'ethers'
 import { utils } from 'ethers'
 
 const DEFAULT_SUBMISSION_PRICE_PERCENT_INCREASE = BigNumber.from(340)
+// Temporary workaround for incorrect gas estimation from NodeInterface when there is gas refund
 const DEFAULT_MAX_GAS_PERCENT_INCREASE = BigNumber.from(50)
 
 /**


### PR DESCRIPTION
Temporary workaround of incorrect gas estimation. Also see https://github.com/OffchainLabs/arb-token-bridge/pull/303