### PR TITLE
fix: Nitro deposit format

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ const l1TxnReceipt = new L1TransactionReceipt(
   txnReceipt /** <-- ethers-js TransactionReceipt of an ethereum tx that triggered an L1 to L2 message (say depositting a token via a bridge)  */
 )
 
-const l1ToL2Message = (await l1TxnReceipt.getL1ToL2Messages(
-  l2Signer /** <-- connected ethers-js Wallet */
-))[0]
+const l1ToL2Message = (
+  await l1TxnReceipt.getL1ToL2Messages(
+    l2Signer /** <-- connected ethers-js Wallet */
+  )
+)[0]
 
 const res = await l1ToL2Message.waitForStatus()
 
@@ -61,11 +63,10 @@ const l2TxnReceipt = new L2TransactionReceipt(
 )
 
 /** Wait 3 minutes: */
-await new Promise(resolve => setTimeout(resolve, 1000 * 60 * 3000));
+await new Promise(resolve => setTimeout(resolve, 1000 * 60 * 3000))
 
 // if dataIsOnL1, sequencer has posted it and it inherits full rollup/L1 security
 const dataIsOnL1 = await l2TxnReceipt.isDataAvailable(l2Provider, l1Provider)
-
 ```
 
 ### Bridging assets

--- a/integration_test/eth.test.ts
+++ b/integration_test/eth.test.ts
@@ -30,7 +30,6 @@ import {
   L2ToL1Message,
   L2ToL1MessageStatus,
 } from '../src/lib/message/L2ToL1Message'
-import { L1ToL2MessageStatus } from '../src/lib/message/L1ToL2Message'
 import { testSetup } from '../scripts/testSetup'
 import { isNitroL2 } from '../src/lib/utils/migration_types'
 dotenv.config()
@@ -92,13 +91,8 @@ describe('Ether', async () => {
     const l1ToL2Messages = await rec.getL1ToL2Messages(l2Signer)
     expect(l1ToL2Messages.length).to.eq(1, 'failed to find 1 l1 to l2 message')
 
-    prettyLog('l2TxHash: ' + waitResult.message.retryableCreationId)
     prettyLog('l2 transaction found!')
     expect(waitResult.complete).to.eq(true, 'eth deposit not complete')
-    expect(waitResult.status).to.eq(
-      L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2,
-      'eth deposit l2 transaction not found'
-    )
 
     const testWalletL2EthBalance = await l2Signer.getBalance()
     if (await isNitroL2(l2Signer)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Update the l1 transaction receipt for eth deposits to follow the nitro format