### PR TITLE
chore: contract packages as dev dependencies, add prepare script

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
     "type": "git",
     "url": "git+https://github.com/offchainlabs/arbitrum-sdk.git"
   },
+  "engines": {
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.0.0"
+  },
   "bugs": {
     "url": "https://github.com/offchainlabs/arbitrum-sdk/issues"
   },
   "homepage": "https://offchainlabs.com",
   "scripts": {
     "audit:ci": "audit-ci -l -a 1067409 1067487 1067486",
-    "prepare": "node ./scripts/genAbi.js",
+    "prepare": "yarn run gen:abi",
     "gen:abi": "node ./scripts/genAbi.js",
     "prepublishOnly": "yarn build && yarn format",
     "preversion": "yarn lint",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://offchainlabs.com",
   "scripts": {
     "audit:ci": "audit-ci -l -a 1067409 1067487 1067486",
-    "postinstall": "node ./scripts/genAbi.js",
+    "prepare": "node ./scripts/genAbi.js",
     "gen:abi": "node ./scripts/genAbi.js",
     "prepublishOnly": "yarn build && yarn format",
     "preversion": "yarn lint",
@@ -45,15 +45,15 @@
     "@typechain/ethers-v5": "9.0.0",
     "@types/prompts": "^2.0.14",
     "@types/yargs": "^17.0.9",
-    "arb-bridge-eth": "0.7.5",
-    "arb-bridge-peripherals": "1.0.6",
-    "arbos-precompiles": "1.0.2",
     "dotenv": "^10.0.0",
     "ethers": "^5.1.0",
     "ts-node": "^10.2.1",
     "typechain": "7.0.0"
   },
   "devDependencies": {
+    "arb-bridge-eth": "0.7.5",
+    "arb-bridge-peripherals": "1.0.6",
+    "arbos-precompiles": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.0.0",


### PR DESCRIPTION
the version bump from https://github.com/OffchainLabs/arbitrum-sdk/pull/66 wasn't published yet, so we can have it as part of the same patch release