### PR TITLE
Fix incorrect comparison

### DIFF
--- a/src/lib/assetBridger/ethBridger.ts
+++ b/src/lib/assetBridger/ethBridger.ts
@@ -127,7 +127,7 @@ export class EthBridger extends AssetBridger<
     // We could alternatively set the submission price to zero here and use the refunds instead, but that
     // would be confusing for users tracking activity in block explorers.
     // This is fixed with nitro's new depositEth message
-    if (submissionPrice >= params.amount)
+    if (submissionPrice.gte(params.amount))
       throw new ArbSdkError('Not enough amount for submission cost')
 
     const inbox = Inbox__factory.connect(


### PR DESCRIPTION
Modify to use the [specified method](https://docs.ethers.io/v5/api/utils/bignumber/#BigNumber--BigNumber--methods--comparison-and-equivalence
) for comparison between BigNumbers.

Using `>=` may return incorrect values.
```node
> a
BigNumber { _hex: '0x2386f26fc10000', _isBigNumber: true }
> b
BigNumber { _hex: '0x3d570965c1', _isBigNumber: true }
> a >= b
false
> a.gte(b)
true
```
