### PR TITLE
fix: surface eth deposits in migration package

### DIFF
--- a/src/lib/message/L1Transaction.ts
+++ b/src/lib/message/L1Transaction.ts
@@ -96,6 +96,14 @@ export class L1TransactionReceipt implements TransactionReceipt {
     this.nitroReceipt = new nitro.L1TransactionReceipt(tx)
   }
 
+  public async getAllDeposits<T extends SignerOrProvider>(l2SignerOrProvider: T) {
+    if (await isNitroL2(l2SignerOrProvider)) {
+      return this.nitroReceipt.getAllDeposits(l2SignerOrProvider)
+    } else {
+      return this.classicReceipt.getL1ToL2Messages(l2SignerOrProvider)
+    }
+  }
+
   /**
    * Get any l1tol2 messages created by this transaction
    * @param l2SignerOrProvider


### PR DESCRIPTION
When using sdk v1 users would get the eth deposit message when interacting with the migration sdk
With the nitro sdk v3, you need a separate function call to get eth deposits.

We should bump up the nitro package to include https://github.com/OffchainLabs/arbitrum-sdk/pull/86 so the `status` function is also available

We could attempt to make `EthDepositMessage` closer to a `IL1ToL2MessageReaderOrWriter` but most methods would throw errors since they don't make sense.

Instead making a separate entrypoint function `getAllDeposits`, need to publish new nitro beta version to consume this here though