### PR TITLE
fix: validate l1 address before returning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -364,7 +364,7 @@ export class Erc20Bridger extends AssetBridger<
 
     // @deprecated: for the next breaking change make the l1Provider required and always do the check below
     if (l1Provider) {
-      await this.checkL1Network(l2Provider)
+      await this.checkL1Network(l1Provider)
       // check that this l1 address is indeed registered to this l2 token
       const l1GatewayRouter = L1GatewayRouter__factory.connect(
         this.l2Network.tokenBridge.l1GatewayRouter,

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -296,6 +296,9 @@ export class Erc20Bridger extends AssetBridger<
 
   /**
    * Get the L2 token contract at the provided address
+   * Note: This function just returns a typed ethers object for the provided address, it doesnt
+   * check the underlying form of the contract bytecode to see if it's an erc20, and doesn't ensure the validity
+   * of any of the underlying functions on that contract.
    * @param l2Provider
    * @param l2TokenAddr
    * @returns
@@ -309,6 +312,9 @@ export class Erc20Bridger extends AssetBridger<
 
   /**
    * Get the L1 token contract at the provided address
+   * Note: This function just returns a typed ethers object for the provided address, it doesnt
+   * check the underlying form of the contract bytecode to see if it's an erc20, and doesn't ensure the validity
+   * of any of the underlying functions on that contract.
    * @param l1Provider
    * @param l1TokenAddr
    * @returns
@@ -354,11 +360,11 @@ export class Erc20Bridger extends AssetBridger<
     await this.checkL2Network(l2Provider)
 
     const arbERC20 = L2GatewayToken__factory.connect(erc20L2Address, l2Provider)
-
     const l1Address = await arbERC20.functions.l1Address().then(([res]) => res)
 
     // @deprecated: for the next breaking change make the l1Provider required and always do the check below
     if (l1Provider) {
+      await this.checkL1Network(l2Provider)
       // check that this l1 address is indeed registered to this l2 token
       const l1GatewayRouter = L1GatewayRouter__factory.connect(
         this.l2Network.tokenBridge.l1GatewayRouter,

--- a/src/lib/dataEntities/errors.ts
+++ b/src/lib/dataEntities/errors.ts
@@ -30,11 +30,11 @@ export class ArbTsError extends Error {
  * Errors originating in Arbitrum SDK
  */
 export class ArbSdkError extends Error {
-  constructor(message: string, public readonly innner?: Error) {
+  constructor(message: string, public readonly inner?: Error) {
     super(message)
 
-    if (innner) {
-      this.stack += '\nCaused By: ' + innner.stack
+    if (inner) {
+      this.stack += '\nCaused By: ' + inner.stack
     }
   }
 }

--- a/src/lib/message/L2ToL1Message.ts
+++ b/src/lib/message/L2ToL1Message.ts
@@ -40,7 +40,7 @@ import {
   SignerProviderUtils,
   SignerOrProvider,
 } from '../dataEntities/signerOrProvider'
-import { getL1Network, getL2Network } from '../dataEntities/networks'
+import { getL2Network } from '../dataEntities/networks'
 import { wait } from '../utils/lib'
 
 export interface MessageBatchProofInfo {


### PR DESCRIPTION
We make the l1provider optional so as not to break the api