### PR TITLE
fix: Updated audit to include undici vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://offchainlabs.com",
   "scripts": {
-    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486",
+    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486 1070905",
     "prepare": "yarn run gen:abi",
     "gen:abi": "node ./scripts/genAbi.js",
     "prepublishOnly": "yarn build && yarn format",


### PR DESCRIPTION
We only use this for hardhat, which we only use in builds which dont make http requests