### PR TITLE
fix: improve getL1ERC20Address error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -364,7 +364,24 @@ export class Erc20Bridger extends AssetBridger<
     try {
       l1Address = (await arbERC20.functions.l1Address())[0]
     } catch (error) {
-      throw new ArbSdkError(`Unable to get l1 address of ${erc20L2Address}`)
+      if (erc20L2Address.toLowerCase() === '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1'){
+        // hardcoding DAI here since it does not implement IArbToken
+        const chainId = (await l2Provider.getNetwork()).chainId
+        if (chainId === 42161){
+          // arbitrum mainnet
+          // the l1Address will still be validated with router
+          l1Address = '0x6b175474e89094c44da98b954eedeac495271d0f'
+        } else if (chainId === 421611){
+          // arbitrum rinkeby
+          // note that DAI's custom gateway was not registered to our router yet
+          // this l1Address will fail the validation
+          l1Address = '0xd9e66a2f546880ea4d800f189d6f12cc15bff281'
+        } else {
+          throw new ArbSdkError(`Unable to get l1 address of ${erc20L2Address}`)
+        }
+      } else {
+        throw new ArbSdkError(`Unable to get l1 address of ${erc20L2Address}`)
+      }
     }
 
     // check that this l1 address is indeed registered to this l2 token

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -363,14 +363,17 @@ export class Erc20Bridger extends AssetBridger<
     try {
       l1Address = (await arbERC20.functions.l1Address())[0]
     } catch (error) {
-      if (erc20L2Address.toLowerCase() === '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1'){
+      if (
+        erc20L2Address.toLowerCase() ===
+        '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1'
+      ) {
         // hardcoding DAI here since it does not implement IArbToken
         const chainId = (await l2Provider.getNetwork()).chainId
-        if (chainId === 42161){
+        if (chainId === 42161) {
           // arbitrum mainnet
           // the l1Address will still be validated with router
           l1Address = '0x6b175474e89094c44da98b954eedeac495271d0f'
-        } else if (chainId === 421611){
+        } else if (chainId === 421611) {
           // arbitrum rinkeby
           // note that DAI's custom gateway was not registered to our router yet
           // this l1Address will fail the validation

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -65,6 +65,7 @@ import {
   L2ContractTransaction,
   L2TransactionReceipt,
 } from '../message/L2Transaction'
+import { L2ERC20Gateway__factory } from '../abi/factories/L2ERC20Gateway__factory'
 
 export interface TokenApproveParams {
   /**
@@ -374,9 +375,19 @@ export class Erc20Bridger extends AssetBridger<
 
     const l2Address = await l2GatewayRouter.calculateL2TokenAddress(l1Address)
     if (l2Address.toLowerCase() !== erc20L2Address.toLowerCase()) {
-      throw new ArbSdkError(
-        `Unexpected l1 address. L1 address from token is not registered to the provided l2 address. ${l1Address} ${l2Address} ${erc20L2Address}`
+      // also check with the standard gateway
+      const l2ERC20Gateway = L2ERC20Gateway__factory.connect(
+        this.l2Network.tokenBridge.l2ERC20Gateway,
+        l2Provider
       )
+      const l2AddressStd = await l2ERC20Gateway.calculateL2TokenAddress(
+        l1Address
+      )
+      if (l2AddressStd.toLowerCase() !== erc20L2Address.toLowerCase()) {
+        throw new ArbSdkError(
+          `Unexpected l1 address. L1 address from token is not registered to the provided l2 address. ${l1Address} ${l2Address} ${erc20L2Address}`
+        )
+      }
     }
 
     return l1Address

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -368,12 +368,11 @@ export class Erc20Bridger extends AssetBridger<
         '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1'
       ) {
         // hardcoding DAI here since it does not implement IArbToken
-        const chainId = (await l2Provider.getNetwork()).chainId
-        if (chainId === 42161) {
+        if (this.l2Network.chainID === 42161) {
           // arbitrum mainnet
           // the l1Address will still be validated with router
           l1Address = '0x6b175474e89094c44da98b954eedeac495271d0f'
-        } else if (chainId === 421611) {
+        } else if (this.l2Network.chainID === 421611) {
           // arbitrum rinkeby
           // note that DAI's custom gateway was not registered to our router yet
           // this l1Address will fail the validation

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -359,7 +359,12 @@ export class Erc20Bridger extends AssetBridger<
     await this.checkL2Network(l2Provider)
 
     const arbERC20 = L2GatewayToken__factory.connect(erc20L2Address, l2Provider)
-    const l1Address = await arbERC20.functions.l1Address().then(([res]) => res)
+    let l1Address
+    try {
+      l1Address = (await arbERC20.functions.l1Address())[0]
+    } catch(error) {
+      throw new ArbSdkError(`Unable to get l1 address of ${erc20L2Address}`)
+    }
 
     // check that this l1 address is indeed registered to this l2 token
     const l2GatewayRouter = L2GatewayRouter__factory.connect(

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -65,7 +65,6 @@ import {
   L2ContractTransaction,
   L2TransactionReceipt,
 } from '../message/L2Transaction'
-import { L2ERC20Gateway__factory } from '../abi/factories/L2ERC20Gateway__factory'
 
 export interface TokenApproveParams {
   /**
@@ -392,19 +391,9 @@ export class Erc20Bridger extends AssetBridger<
 
     const l2Address = await l2GatewayRouter.calculateL2TokenAddress(l1Address)
     if (l2Address.toLowerCase() !== erc20L2Address.toLowerCase()) {
-      // also check with the standard gateway
-      const l2ERC20Gateway = L2ERC20Gateway__factory.connect(
-        this.l2Network.tokenBridge.l2ERC20Gateway,
-        l2Provider
+      throw new ArbSdkError(
+        `Unexpected l1 address. L1 address from token is not registered to the provided l2 address. ${l1Address} ${l2Address} ${erc20L2Address}`
       )
-      const l2AddressStd = await l2ERC20Gateway.calculateL2TokenAddress(
-        l1Address
-      )
-      if (l2AddressStd.toLowerCase() !== erc20L2Address.toLowerCase()) {
-        throw new ArbSdkError(
-          `Unexpected l1 address. L1 address from token is not registered to the provided l2 address. ${l1Address} ${l2Address} ${erc20L2Address}`
-        )
-      }
     }
 
     return l1Address

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -362,7 +362,7 @@ export class Erc20Bridger extends AssetBridger<
     let l1Address
     try {
       l1Address = (await arbERC20.functions.l1Address())[0]
-    } catch(error) {
+    } catch (error) {
       throw new ArbSdkError(`Unable to get l1 address of ${erc20L2Address}`)
     }
 


### PR DESCRIPTION
For token without .l1Address() (e.g. DAI), `getL1ERC20Address` will throw with CALL_EXCEPTION

https://github.com/OffchainLabs/arbitrum-sdk/blob/afd58837a06f4e061b8f56f26db14e50439c7d7b/src/lib/assetBridger/erc20Bridger.ts#L355-362
```solidity
  public async getL1ERC20Address(
    erc20L2Address: string,
    l2Provider: Provider
  ): Promise<string> {
    await this.checkL2Network(l2Provider)

    const arbERC20 = L2GatewayToken__factory.connect(erc20L2Address, l2Provider)
    const l1Address = await arbERC20.functions.l1Address().then(([res]) => res)
```

There doesn't seems to be any on-chain registry that can resolve a L2 -> L1 address mapping. Another question is do we want to special case DAI by hardcoding the address here (but still do the validation to make it less risky).

Also added a validation fallback in [8b5467d](https://github.com/OffchainLabs/arbitrum-sdk/pull/94/commits/8b5467de95176db05755b99af1a253c827760ed9). 