### PR TITLE
Throw on waitForStatus timeout

### DIFF
--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -451,6 +451,10 @@ export class L1ToL2MessageReader extends L1ToL2Message {
       confirmations,
       timeout
     )
+    if (!_retryableCreationReceipt)
+      throw new ArbSdkError(
+        `Retryable creation receipt not found ${this.retryableCreationId}`
+      )
     return await this.getSuccessfulRedeem()
   }
 


### PR DESCRIPTION
Throw as described in spec, also if we don't throw here we will call `getSuccessfulRedeem` which will then call `getRetryableCreationReceipt` with default timeout (15m).