### PR TITLE
fix classic network pairings to include nitro specific networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@arbitrum/sdk-classic": "npm:@arbitrum/sdk@1.1.13",
-    "@arbitrum/sdk-nitro": "npm:@arbitrum/sdk@3.0.0-beta.7",
+    "@arbitrum/sdk-nitro": "npm:@arbitrum/sdk@3.0.0-beta.8",
     "@ethersproject/address": "^5.0.8",
     "@ethersproject/bignumber": "^5.1.1",
     "@ethersproject/bytes": "^5.0.8",

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -20,9 +20,15 @@ import dotenv from 'dotenv'
 import { SignerOrProvider } from './signerOrProvider'
 
 import * as classic from '@arbitrum/sdk-classic'
-import { l1Networks as classicl1Networks } from '@arbitrum/sdk-classic/dist/lib/dataEntities/networks'
+import {
+  l1Networks as classicl1Networks,
+  l2Networks as classicL2Networks
+} from '@arbitrum/sdk-classic/dist/lib/dataEntities/networks'
 import * as nitro from '@arbitrum/sdk-nitro'
-import { l1Networks as nitrol1Networks } from '@arbitrum/sdk-nitro/dist/lib/dataEntities/networks'
+import {
+  l1Networks as nitrol1Networks,
+  l2Networks as nitroL2Networks
+} from '@arbitrum/sdk-nitro/dist/lib/dataEntities/networks'
 import {
   convertNetworkClassicToNitro,
   convertNetworkNitroToClassic,
@@ -138,3 +144,13 @@ export const isL1Network = (
   if ((network as L1Network).partnerChainIDs) return true
   else return false
 }
+
+function patchClassicNetworkWithNitro() {
+  // adds nitro specific networks to the classic package to avoid breakage
+  classicl1Networks[1].partnerChainIDs.push(42170)
+  classicl1Networks[5] = nitrol1Networks[5]
+  classicL2Networks[421613] = convertNetworkNitroToClassic(nitroL2Networks[421613])
+  classicL2Networks[42170] = convertNetworkNitroToClassic(nitroL2Networks[42170])
+}
+
+patchClassicNetworkWithNitro();

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -22,12 +22,12 @@ import { SignerOrProvider } from './signerOrProvider'
 import * as classic from '@arbitrum/sdk-classic'
 import {
   l1Networks as classicl1Networks,
-  l2Networks as classicL2Networks
+  l2Networks as classicL2Networks,
 } from '@arbitrum/sdk-classic/dist/lib/dataEntities/networks'
 import * as nitro from '@arbitrum/sdk-nitro'
 import {
   l1Networks as nitrol1Networks,
-  l2Networks as nitroL2Networks
+  l2Networks as nitroL2Networks,
 } from '@arbitrum/sdk-nitro/dist/lib/dataEntities/networks'
 import {
   convertNetworkClassicToNitro,
@@ -149,8 +149,12 @@ function patchClassicNetworkWithNitro() {
   // adds nitro specific networks to the classic package to avoid breakage
   classicl1Networks[1].partnerChainIDs.push(42170)
   classicl1Networks[5] = nitrol1Networks[5]
-  classicL2Networks[421613] = convertNetworkNitroToClassic(nitroL2Networks[421613])
-  classicL2Networks[42170] = convertNetworkNitroToClassic(nitroL2Networks[42170])
+  classicL2Networks[421613] = convertNetworkNitroToClassic(
+    nitroL2Networks[421613]
+  )
+  classicL2Networks[42170] = convertNetworkNitroToClassic(
+    nitroL2Networks[42170]
+  )
 }
 
-patchClassicNetworkWithNitro();
+patchClassicNetworkWithNitro()

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,10 +35,10 @@
     ts-node "^10.2.1"
     typechain "7.0.0"
 
-"@arbitrum/sdk-nitro@npm:@arbitrum/sdk@3.0.0-beta.7":
-  version "3.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.0.0-beta.7.tgz#c89de9eae75c0b98e8aeb0f13d7e0e5ff4380ff0"
-  integrity sha512-aMxHBESSt00CiBetP2Bixkf45zg4Q8q0TIBi6D8U4+e13+Qwldv7rjuuNSNVBJg4T51QKrn/ZQtkzUEA66paMg==
+"@arbitrum/sdk-nitro@npm:@arbitrum/sdk@3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.0.0-beta.8.tgz#639981b0772309552576a61ce66edcb98505a97c"
+  integrity sha512-wSjzilBc2rSAPqJXvr5tIs/1W8SAqBdi/XseH3IwziUiXLcZdZ+yHanN6FfNtwk0Ij6HY9D4Qt3ZLhW0E+LM7A==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"


### PR DESCRIPTION
this allows us to remove the patch that currently lives in the token bridge UI https://github.com/OffchainLabs/arb-token-bridge/blob/1d2a3b327a063e8ac271987bec5d5508e1b19c52/packages/arb-token-bridge-ui/src/util/networks.ts#L7-L17


this specific line was added [previously](https://github.com/OffchainLabs/arbitrum-sdk/commit/6a617e6d13e225e335671cd60514b1afada1ab26)
```
NitroNetworks.l1Networks[1].partnerChainIDs.push(42170)
```