### PR TITLE
Updated the audit list

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://offchainlabs.com",
   "scripts": {
-    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486 1070905 1081496 1081677 1081697 1081680 1081682 1081679 1081681 1081989 1081919 1081990 1081920 1081921 1081848",
+    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486 1081677 1081989 1081919 1081990 1081920 1081921 1081848 1083165 1083163",
     "prepare": "yarn run gen:abi",
     "gen:abi": "node ./scripts/genAbi.js",
     "gen:network": "ts-node ./scripts/genNetwork.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://offchainlabs.com",
   "scripts": {
-    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486 1070905 1081496 1081677 1081697 1081680 1081682 1081679 1081681",
+    "audit:ci": "audit-ci -l -a 1067409 1067487 1067486 1070905 1081496 1081677 1081697 1081680 1081682 1081679 1081681 1081989 1081919 1081990 1081920 1081921 1081848",
     "prepare": "yarn run gen:abi",
     "gen:abi": "node ./scripts/genAbi.js",
     "gen:network": "ts-node ./scripts/genNetwork.ts",

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -246,7 +246,8 @@ export const l2Networks: L2Networks = {
     name: 'Arbitrum Nova',
     partnerChainID: 1,
     retryableLifetimeSeconds: SEVEN_DAYS_IN_SECONDS,
-    rpcURL: process.env['NOVA_RPC'] as string || 'https://nova.arbitrum.io/rpc',
+    rpcURL:
+      (process.env['NOVA_RPC'] as string) || 'https://nova.arbitrum.io/rpc',
     tokenBridge: {
       l1CustomGateway: '0x23122da8C581AA7E0d07A36Ff1f16F799650232f',
       l1ERC20Gateway: '0xB2535b988dcE19f9D71dfB22dB6da744aCac21bf',


### PR DESCRIPTION
Mostly the same as https://github.com/OffchainLabs/arbitrum-sdk/pull/123, except the numbers have changed.

[1081677](https://github.com/advisories/GHSA-3cvr-822r-rqcc) 
[1081921](https://github.com/advisories/GHSA-q768-x9m6-m9qp)
[1081848](https://github.com/advisories/GHSA-pgw7-wx7w-2w33)
Undici, hardhat build stuff, we only use this in dev, and even there we only use local stuff so undici is never called

[1081989](https://github.com/advisories/GHSA-qh9x-gcfh-pcrw)
[1081990](https://github.com/advisories/GHSA-qh9x-gcfh-pcrw)
[1083165](https://github.com/advisories/GHSA-7grf-83vw-6f5x)
[1083163](https://github.com/advisories/GHSA-7grf-83vw-6f5x)
OZ ERC165 - not used by us

[1081919](https://github.com/advisories/GHSA-4g63-c64m-25w9)
[1081920](https://github.com/advisories/GHSA-4g63-c64m-25w9)
OZ SigChecker ERC 1271 - not used by us