### PR TITLE
Populate the l1rpc if it isnt populated already, used in the tutorials

### DIFF
--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -29,6 +29,7 @@ import {
   isNitroL1,
   isNitroL2,
 } from '../utils/migration_types'
+import { isDefined } from '../utils/lib'
 
 dotenv.config()
 
@@ -91,11 +92,20 @@ export const getL1Network = async (
   signerOrProvider: SignerOrProvider,
   l2ChainId: number
 ): Promise<L1Network> => {
-  if (await isNitroL1(l2ChainId, signerOrProvider)) {
-    return await nitro.getL1Network(signerOrProvider)
-  } else {
-    return await classic.getL1Network(signerOrProvider)
-  }
+  const network = await (async () => {
+    if (await isNitroL1(l2ChainId, signerOrProvider)) {
+      return await nitro.getL1Network(signerOrProvider)
+    } else {
+      return await classic.getL1Network(signerOrProvider)
+    }
+  })()
+
+  return isDefined(network.rpcURL)
+    ? network
+    : {
+        ...network,
+        rpcURL: process.env['L1RPC'],
+      }
 }
 export const getL2Network = async (
   signerOrProvider: SignerOrProvider

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -92,13 +92,9 @@ export const getL1Network = async (
   signerOrProvider: SignerOrProvider,
   l2ChainId: number
 ): Promise<L1Network> => {
-  const network = await (async () => {
-    if (await isNitroL1(l2ChainId, signerOrProvider)) {
-      return await nitro.getL1Network(signerOrProvider)
-    } else {
-      return await classic.getL1Network(signerOrProvider)
-    }
-  })()
+  const network =
+      ((await isNitroL1(l2ChainId, signerOrProvider)) ? nitro : classic)
+          .getL1Network(signerOrProvider)
 
   return isDefined(network.rpcURL)
     ? network

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -92,9 +92,9 @@ export const getL1Network = async (
   signerOrProvider: SignerOrProvider,
   l2ChainId: number
 ): Promise<L1Network> => {
-  const network =
-      ((await isNitroL1(l2ChainId, signerOrProvider)) ? nitro : classic)
-          .getL1Network(signerOrProvider)
+  const network = (
+    (await isNitroL1(l2ChainId, signerOrProvider)) ? nitro : classic
+  ).getL1Network(signerOrProvider)
 
   return isDefined(network.rpcURL)
     ? network


### PR DESCRIPTION
This is only a problem with the migration package, where isNitroL2 needs to get l1 rpc url, so we put onto the network object with an env var