### PR TITLE
Enhancement (V3) : Attach the ”isArbitrum: false"  property to L1 networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ As part of normal operation the Arbitrum sequencer will messages into the rollup
 
 ### Run Integration tests
 
-`yarn test:integration`
+1. First, make sure you have a Nitro node running. Check out the nitro repo, and run the following command `./test-node.bash --init --no-blockscout`
+
+2. After the node has started up (that could take upto 20-30 mins), run `yarn gen:network`.
+
+3. Once done, finally run `yarn test:integration` to run the integration tests.
+
 
 Defaults to `rinkArby`, for custom network use `--network` flag.
 

--- a/scripts/testSetup.ts
+++ b/scripts/testSetup.ts
@@ -88,6 +88,7 @@ export const getCustomNetworks = async (
     isCustom: true,
     name: 'EthLocal',
     partnerChainIDs: [l2NetworkInfo.chainId],
+    isArbitrum: false,
   }
 
   const l2Network: Omit<L2Network, 'tokenBridge'> = {

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -23,6 +23,7 @@ import { SEVEN_DAYS_IN_SECONDS } from './constants'
 export interface L1Network extends Network {
   partnerChainIDs: number[]
   blockTime: number //seconds
+  isArbitrum: false
 }
 
 export interface L2Network extends Network {
@@ -132,6 +133,7 @@ export const l1Networks: L1Networks = {
     partnerChainIDs: [42161, 42170],
     blockTime: 14,
     isCustom: false,
+    isArbitrum: false,
   },
   1338: {
     chainID: 1338,
@@ -140,6 +142,7 @@ export const l1Networks: L1Networks = {
     partnerChainIDs: [42161],
     blockTime: 1,
     isCustom: false,
+    isArbitrum: false,
   },
   4: {
     chainID: 4,
@@ -148,6 +151,7 @@ export const l1Networks: L1Networks = {
     partnerChainIDs: [421611],
     blockTime: 15,
     isCustom: false,
+    isArbitrum: false,
   },
   5: {
     blockTime: 15,
@@ -156,6 +160,7 @@ export const l1Networks: L1Networks = {
     isCustom: false,
     name: 'Goerli',
     partnerChainIDs: [421613],
+    isArbitrum: false,
   },
 }
 


### PR DESCRIPTION
Attach the `isArbitrum: false` property to L1 networks.
This will make it nicer to work with cases where your type is `L1Network | L2Network` and you need to check if it’s Arbitrum (without checking the id).