### PR TITLE
chore: undo package bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "3.0.0-beta.13",
+  "version": "3.0.0-beta.12",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
the package didn't need to be bumped in https://github.com/OffchainLabs/arbitrum-sdk/pull/180/commits/834a3d4e7fa672caa4e0eb2afd540cd68bf24939 since the previous version had not been published