### PR TITLE
fix: check inbox of bridgeMessageEvent

### DIFF
--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -128,43 +128,45 @@ export const checkRetryableStatus = async (l1Hash: string): Promise<void> => {
   const l2Provider = l2Signer.provider!
   const rec = await l1Provider.getTransactionReceipt(l1Hash)
   if (!rec) throw new Error('L1 tx not found!')
-  const message = (
-    await new L1TransactionReceipt(rec).getL1ToL2Messages(l2Provider)
-  )[0]
+  const messages = await new L1TransactionReceipt(rec).getL1ToL2Messages(
+    l2Provider
+  )
 
-  if (!message) throw new Error('no seq nums')
+  for (const message of messages) {
+    if (!message) throw new Error('no seq nums')
 
-  const messageStatus = await message.waitForStatus()
+    const messageStatus = await message.waitForStatus()
 
-  const autoRedeemTxnRec = await message.getAutoRedeemAttempt()
-  const autoRedeemTxnHash = autoRedeemTxnRec
-    ? autoRedeemTxnRec.transactionHash
-    : null
-
-  const retryableTicketId = message.retryableCreationId
-  const retryableTicketRec =
-    messageStatus.status === L1ToL2MessageStatus.REDEEMED
-      ? messageStatus.l2TxReceipt
+    const autoRedeemTxnRec = await message.getAutoRedeemAttempt()
+    const autoRedeemTxnHash = autoRedeemTxnRec
+      ? autoRedeemTxnRec.transactionHash
       : null
 
-  console.log('*** autoRedeemTxnHash', autoRedeemTxnHash)
-  console.log(
-    '*** autoRedeemTxn status',
-    autoRedeemTxnRec ? autoRedeemTxnRec.status : autoRedeemTxnRec
-  )
-  if (autoRedeemTxnRec && autoRedeemTxnRec.status !== 1) {
-    console.log('**** autoRedeemTxn receipt', autoRedeemTxnHash)
-  }
+    const retryableTicketId = message.retryableCreationId
+    const retryableTicketRec =
+      messageStatus.status === L1ToL2MessageStatus.REDEEMED
+        ? messageStatus.l2TxReceipt
+        : null
 
-  console.log('*** retryableTicketId', retryableTicketId)
-  console.log(
-    '*** retryableTicket status',
-    retryableTicketRec ? retryableTicketRec.status : messageStatus.status
-  )
-  if (retryableTicketRec) {
+    console.log('*** autoRedeemTxnHash', autoRedeemTxnHash)
     console.log(
-      '**** retryableTicket receipt',
-      retryableTicketRec.transactionHash
+      '*** autoRedeemTxn status',
+      autoRedeemTxnRec ? autoRedeemTxnRec.status : autoRedeemTxnRec
     )
+    if (autoRedeemTxnRec && autoRedeemTxnRec.status !== 1) {
+      console.log('**** autoRedeemTxn receipt', autoRedeemTxnHash)
+    }
+
+    console.log('*** retryableTicketId', retryableTicketId)
+    console.log(
+      '*** retryableTicket status',
+      retryableTicketRec ? retryableTicketRec.status : messageStatus.status
+    )
+    if (retryableTicketRec) {
+      console.log(
+        '**** retryableTicket receipt',
+        retryableTicketRec.transactionHash
+      )
+    }
   }
 }

--- a/src/lib/message/L1Transaction.ts
+++ b/src/lib/message/L1Transaction.ts
@@ -207,7 +207,8 @@ export class L1TransactionReceipt implements TransactionReceipt {
         e =>
           e.bridgeMessageEvent.kind ===
             InboxMessageKind.L1MessageType_submitRetryableTx &&
-          e.bridgeMessageEvent.inbox === network.ethBridge.inbox
+          e.bridgeMessageEvent.inbox.toLowerCase() ===
+            network.ethBridge.inbox.toLowerCase()
       )
       .map(mn => {
         const messageDataParser = new SubmitRetryableMessageDataParser()


### PR DESCRIPTION
`getL1ToL2Messages` did not check if the bridgeMessageEvent is from the inbox matching the supplied l2provider. 
https://github.com/OffchainLabs/arbitrum-sdk/blob/f6f4c5862baaa6c7537ece45e26d0d7d10d2ff3c/src/lib/message/L1Transaction.ts#L215-L221

If the same L1 tx send to both arb1 and nova some invalid retryable will show up. i.e.

1. nova data with nova chainid
2. arb1 data with nova chainid (invalid)
3. arb1 data with arb1 chainid
4. nova data with arb1 chainid (invalid)

e.g.
https://retryable-dashboard.arbitrum.io/?t=0xc69036ab70acdd288f6db6aff67b6ac1a3f92cfc855d93b5629e1a0ee8f28cbc