### PR TITLE
adding EthDepositStatus

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './lib/message/L1Transaction'
 export {
   L1ToL2MessageStatus,
+  EthDepositStatus,
   L1ToL2Message,
   L1ToL2MessageReader,
   L1ToL2MessageWriter,

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -68,13 +68,13 @@ export enum L1ToL2MessageStatus {
 
 export enum EthDepositStatus {
   /**
-   * Ethers are not deposited on L2 yet
+   * ETH is not deposited on L2 yet
    */
-   NOT_YET_DEPOSITED_ON_L2 = 1,
+   PENDING= 1,
   /**
-   * Ethers are deposited successfully on L2
+   * ETH is deposited successfully on L2
    */
-  FUNDS_DEPOSITED_ON_L2 = 2,
+   DEPOSITED = 2,
 }
 
 /**

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -70,11 +70,11 @@ export enum EthDepositStatus {
   /**
    * ETH is not deposited on L2 yet
    */
-   PENDING= 1,
+  PENDING = 1,
   /**
    * ETH is deposited successfully on L2
    */
-   DEPOSITED = 2,
+  DEPOSITED = 2,
 }
 
 /**

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -66,6 +66,17 @@ export enum L1ToL2MessageStatus {
   EXPIRED = 5,
 }
 
+export enum EthDepositStatus {
+  /**
+   * Ethers are not deposited on L2 yet
+   */
+   NOT_YET_DEPOSITED_ON_L2 = 1,
+  /**
+   * Ethers are deposited successfully on L2
+   */
+  FUNDS_DEPOSITED_ON_L2 = 2,
+}
+
 /**
  * Conditional type for Signer or Provider. If T is of type Provider
  * then L1ToL2MessageReaderOrWriter<T> will be of type L1ToL2MessageReader.
@@ -719,12 +730,12 @@ export class EthDepositMessage {
     )
   }
 
-  public async status(): Promise<L1ToL2MessageStatus> {
+  public async status(): Promise<EthDepositStatus> {
     const receipt = await this.l2Provider.getTransactionReceipt(
       this.l2DepositTxHash
     )
-    if (receipt === null) return L1ToL2MessageStatus.NOT_YET_CREATED
-    else return L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2
+    if (receipt === null) return EthDepositStatus.NOT_YET_DEPOSITED_ON_L2
+    else return EthDepositStatus.FUNDS_DEPOSITED_ON_L2
   }
 
   public async wait(confirmations?: number, timeout?: number) {

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -734,8 +734,8 @@ export class EthDepositMessage {
     const receipt = await this.l2Provider.getTransactionReceipt(
       this.l2DepositTxHash
     )
-    if (receipt === null) return EthDepositStatus.NOT_YET_DEPOSITED_ON_L2
-    else return EthDepositStatus.FUNDS_DEPOSITED_ON_L2
+    if (receipt === null) return EthDepositStatus.PENDING
+    else return EthDepositStatus.DEPOSITED
   }
 
   public async wait(confirmations?: number, timeout?: number) {


### PR DESCRIPTION
In v3.0.0-rc.1, we used L1ToL2MessageStatus for ETH deposits which doesn't makes sense for "NOT_YET_CREATED" status. In this PR we added EthDepositStatus that represents status for ETH deposits.