### PR TITLE
feat: create asset bridger from provider

### DIFF
--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -45,7 +45,7 @@ import {
   L1ToL2MessageGasEstimator,
 } from '../message/L1ToL2MessageGasEstimator'
 import { SignerProviderUtils } from '../dataEntities/signerOrProvider'
-import { L2Network } from '../dataEntities/networks'
+import { L2Network, getL2Network } from '../dataEntities/networks'
 import { ArbSdkError, MissingProviderArbSdkError } from '../dataEntities/errors'
 import { DISABLED_GATEWAY } from '../dataEntities/constants'
 import { EventFetcher } from '../utils/eventFetcher'
@@ -180,6 +180,15 @@ export class Erc20Bridger extends AssetBridger<
    */
   public constructor(l2Network: L2Network) {
     super(l2Network)
+  }
+
+  /**
+   * Instantiates a new Erc20Bridger from an L2 Provider
+   * @param l2Provider
+   * @returns
+   */
+  public static async fromProvider(l2Provider: Provider) {
+    return new Erc20Bridger(await getL2Network(l2Provider))
   }
 
   /**

--- a/src/lib/assetBridger/ethBridger.ts
+++ b/src/lib/assetBridger/ethBridger.ts
@@ -42,6 +42,7 @@ import {
 import { OmitTyped } from '../utils/types'
 import { SignerProviderUtils } from '../dataEntities/signerOrProvider'
 import { MissingProviderArbSdkError } from '../dataEntities/errors'
+import { getL2Network } from '../dataEntities/networks'
 
 export interface EthWithdrawParams {
   /**
@@ -99,6 +100,15 @@ export class EthBridger extends AssetBridger<
   EthDepositParams | L1ToL2TxReqAndSigner,
   EthWithdrawParams | L2ToL1TxReqAndSigner
 > {
+  /**
+   * Instantiates a new EthBridger from an L2 Provider
+   * @param l2Provider
+   * @returns
+   */
+  public static async fromProvider(l2Provider: Provider) {
+    return new EthBridger(await getL2Network(l2Provider))
+  }
+
   /**
    * Get a transaction request for an eth deposit
    * @param params


### PR DESCRIPTION
Adds a static `fromProvider` method to both `EthBridger` and `Erc20Bridger` classes, allowing the client to instantiate objects without needing the `L2Network` object.