### PR TITLE
fix: withdrawal blocks remaining

### DIFF
--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -368,7 +368,7 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
       return BigNumber.from(l2Network.confirmPeriodBlocks)
         .add(ASSERTION_CREATED_PADDING)
         .add(ASSERTION_CONFIRMED_PADDING)
-        .add(latestBlock)
+        .add(this.event.ethBlockNum)
 
     // use binary search to find the first node with sendCount > this.event.position
     // default to the last node since we already checked above


### PR DESCRIPTION
When calculating first executable block we add current block number instead of execution block number