### PR TITLE
feat: add method for depositing eth to a different address

### DIFF
--- a/src/lib/assetBridger/ethBridger.ts
+++ b/src/lib/assetBridger/ethBridger.ts
@@ -208,6 +208,7 @@ export class EthBridger extends AssetBridger<
       ...params,
       to: params.destinationAddress,
       l2CallValue: params.amount,
+      callValueRefundAddress: params.destinationAddress,
       data: '0x',
     }
 

--- a/src/lib/assetBridger/ethBridger.ts
+++ b/src/lib/assetBridger/ethBridger.ts
@@ -244,14 +244,11 @@ export class EthBridger extends AssetBridger<
           l1Provider: params.l1Signer.provider!,
         })
 
-    const l1ToL2MessageCreator = new L1ToL2MessageCreator(params.l1Signer)
-    const tx = await l1ToL2MessageCreator.createRetryableTicket(
-      retryableTicketRequest,
-      params.l2Provider
-    )
+    const tx = await params.l1Signer.sendTransaction({
+      ...retryableTicketRequest.txRequest,
+      ...params.overrides,
+    })
 
-    // Replace the wait() function from monkeyPatchWait (in createRetryableTicket)
-    // with this one, so we have method waitForL2() available
     return L1TransactionReceipt.monkeyPatchContractCallWait(tx)
   }
 

--- a/tests/integration/eth.test.ts
+++ b/tests/integration/eth.test.ts
@@ -136,14 +136,12 @@ describe('Ether', async () => {
       inboxAddress
     )
     const ethToDeposit = parseEther('0.0002')
-    const res = await ethBridger.depositTo(
-      {
-        amount: ethToDeposit,
-        l1Signer: l1Signer,
-        destinationAddress: destWallet.address,
-      },
-      l2Signer.provider!
-    )
+    const res = await ethBridger.depositTo({
+      amount: ethToDeposit,
+      l1Signer: l1Signer,
+      destinationAddress: destWallet.address,
+      l2Provider: l2Signer.provider!,
+    })
     const rec = await res.wait()
 
     expect(rec.status).to.equal(1, 'eth deposit L1 txn failed')

--- a/tests/integration/eth.test.ts
+++ b/tests/integration/eth.test.ts
@@ -140,7 +140,7 @@ describe('Ether', async () => {
       {
         amount: ethToDeposit,
         l1Signer: l1Signer,
-        to: destWallet.address,
+        destinationAddress: destWallet.address,
       },
       l2Signer.provider!
     )


### PR DESCRIPTION
New `ethBridger.depositTo` method that allows a user to deposit ETH to a different address on L2 by using a Retryable Ticket.
There are different ways to implement the function, but I've prioritized having a simpler function body and just using the parameters to create the retryable ticket (instead of having a more similar function signature to that of `deposit()` and a slightly more complex body).

Added also a test to `eth.test.ts`.

Closes https://github.com/OffchainLabs/arbitrum-sdk/issues/219.