### PR TITLE
Update export for consistency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   EthDepositStatus,
   L1ToL2Message,
   L1ToL2MessageReader,
+  L1ToL2MessageReaderClassic,
   L1ToL2MessageWriter,
 } from './lib/message/L1ToL2Message'
 export { L1ToL2MessageGasEstimator } from './lib/message/L1ToL2MessageGasEstimator'


### PR DESCRIPTION
Updated export to be consistent. They can now both be imported through `import { L1ToL2MessageReader, L1ToL2MessageReaderClassic } from '@arbitrum/sdk';`