### PR TITLE
fix: retryable rlp when destAddress is 0x0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -145,7 +145,7 @@ export abstract class L1ToL2Message {
       formatNumber(maxFeePerGas),
       formatNumber(gasLimit),
       // when destAddress is 0x0, arbos treat that as nil
-      destAddress == ethers.constants.AddressZero ? '0x' : destAddress,
+      destAddress === ethers.constants.AddressZero ? '0x' : destAddress,
       formatNumber(l2CallValue),
       callValueRefundAddress,
       formatNumber(maxSubmissionFee),

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -144,7 +144,7 @@ export abstract class L1ToL2Message {
       formatNumber(l1Value),
       formatNumber(maxFeePerGas),
       formatNumber(gasLimit),
-      // when destAddress is 0x0, arbos treat that as contract deployment e.g. to == undefined
+      // when destAddress is 0x0, arbos treat that as nil
       destAddress == ethers.constants.AddressZero ? '0x' : destAddress,
       formatNumber(l2CallValue),
       callValueRefundAddress,

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -144,7 +144,8 @@ export abstract class L1ToL2Message {
       formatNumber(l1Value),
       formatNumber(maxFeePerGas),
       formatNumber(gasLimit),
-      destAddress,
+      // when destAddress is 0x0, arbos treat that as contract deployment e.g. to == undefined
+      destAddress == ethers.constants.AddressZero ? '0x' : destAddress,
       formatNumber(l2CallValue),
       callValueRefundAddress,
       formatNumber(maxSubmissionFee),


### PR DESCRIPTION
When retryTo is set to 0x0, ArbOS treat it as nil and do contract deployment instead of sending to address(0)
https://github.com/OffchainLabs/go-ethereum/blob/01cc043469b25ca03a296be256aae2082c161bd7/core/types/arb_types.go#L50
This lead to a bug in how the sdk calculate retryableid when retryTo is 0x0

Example:
L1 Tx: https://etherscan.io/tx/0xbe273cc350c0e4f3350cd7a2a63d802ad9cf071b1f724e60dfb3d5b374604878
RetryableId before fix: [0x7bd9445851a206f6f30a610797bc88d8fbad19581023996a9030977a1bd77722](https://retryable-dashboard.arbitrum.io/tx/0xbe273cc350c0e4f3350cd7a2a63d802ad9cf071b1f724e60dfb3d5b374604878)
RetryableId after fix: [0x89d991be089b33e98f4a3aa5e4bc87f22e45e28a943e09bec929ec27119f5492](https://arbiscan.io/tx/0x89d991be089b33e98f4a3aa5e4bc87f22e45e28a943e09bec929ec27119f5492)
