### PR TITLE
Increase default timeout for the creation and redemption of retryable tickets

### DIFF
--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -159,8 +159,10 @@ export const l2Networks: L2Networks = {
     nitroGenesisL1Block: 15447158,
     /**
      * Finalisation on mainnet can be up to 2 epochs = 64 blocks on mainnet
+     * We add 10 minutes for the system to create and redeem the ticket, plus some extra buffer of time
+     * (Total timeout: 30 minutes)
      */
-    depositTimeout: 888000,
+    depositTimeout: 1800000,
   },
   421613: {
     chainID: 421613,
@@ -236,7 +238,12 @@ export const l2Networks: L2Networks = {
     },
     nitroGenesisBlock: 0,
     nitroGenesisL1Block: 0,
-    depositTimeout: 888000,
+    /**
+     * Finalisation on mainnet can be up to 2 epochs = 64 blocks on mainnet
+     * We add 10 minutes for the system to create and redeem the ticket, plus some extra buffer of time
+     * (Total timeout: 30 minutes)
+     */
+    depositTimeout: 1800000,
   },
 }
 


### PR DESCRIPTION
Increased to 30 minutes in both One and Nova
2 epochs => ~13 minutes
Time to create and redeem the ticket => ~10 minutes
Extra buffer of time => ~7 minutes