### PR TITLE
chore: bump sdk for orbit support

### DIFF
--- a/hardhat-abigen.ts
+++ b/hardhat-abigen.ts
@@ -1,0 +1,18 @@
+/**
+ * @type import('hardhat/config').HardhatUserConfig
+ */
+module.exports = {
+    solidity: {
+      version: '0.8.9',
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 100,
+        },
+      },
+    },
+    paths: {
+      sources: './src',
+      artifacts: './build/contracts',
+    },
+  }

--- a/hardhat-abigen.ts
+++ b/hardhat-abigen.ts
@@ -2,17 +2,17 @@
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
-    solidity: {
-      version: '0.8.9',
-      settings: {
-        optimizer: {
-          enabled: true,
-          runs: 100,
-        },
+  solidity: {
+    version: '0.8.9',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 100,
       },
     },
-    paths: {
-      sources: './src',
-      artifacts: './build/contracts',
-    },
-  }
+  },
+  paths: {
+    sources: './src',
+    artifacts: './build/contracts',
+  },
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "3.1.3",
+  "version": "3.2.0-alpha.0",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ethers": "^5.1.0"
   },
   "devDependencies": {
-    "@arbitrum/nitro-contracts": "1.0.1",
+    "@arbitrum/nitro-contracts": "1.1.0-alpha.0",
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@typechain/ethers-v5": "9.0.0",
     "@types/chai": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",

--- a/scripts/genAbi.js
+++ b/scripts/genAbi.js
@@ -27,8 +27,11 @@ async function main() {
   // https://yarnpkg.com/advanced/rulebook#packages-should-never-write-inside-their-own-folder-outside-of-postinstall
   // instead of writing in postinstall in each of those packages, we should target a local folder in sdk's postinstall
 
+  // copy the hardhat config to the nitro package
+  execSync(`cp ${cwd}/hardhat-abigen.ts ${nitroPath}/hardhat-abigen.ts`)
+
   console.log('building nitro')
-  execSync(`${npmExec} run hardhat:prod compile`, {
+  execSync(`${npmExec} run build --config hardhat-abigen.ts`, {
     cwd: nitroPath,
   })
 

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -39,7 +39,7 @@ import {
   SignerOrProvider,
 } from '../dataEntities/signerOrProvider'
 import { wait } from '../utils/lib'
-import { getL2Network } from '../dataEntities/networks'
+import { getL2Network, l2Networks } from '../dataEntities/networks'
 import { NodeCreatedEvent, RollupUserLogic } from '../abi/RollupUserLogic'
 import { ArbitrumProvider } from '../utils/arbProvider'
 import { ArbBlock } from '../dataEntities/rpc'
@@ -334,22 +334,26 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
       throw new ArbSdkError('L2ToL1Msg expected to be unconfirmed')
 
     const latestBlock = await this.l1Provider.getBlockNumber()
+    const isL3 = l2Networks[l2Network.partnerChainID] !== undefined
+    // The original logic does not work on a L3 where the base chain is a Arbitrum Chain because
+    // latestBlock would be in L2 blocks but confirmPeriodBlocks and ASSERTION_CONFIRMED_PADDING are in L1 blocks
+    const rollupCreatedAtBlock = isL3
+      ? (await rollup.getNodeCreationBlockForLogLookup(0)).toNumber() // dirty hack to do a full range event lookup, TODO: fix this
+      : Math.max(
+          latestBlock -
+            BigNumber.from(l2Network.confirmPeriodBlocks)
+              .add(ASSERTION_CONFIRMED_PADDING)
+              .toNumber(),
+          0
+        )
+
     const eventFetcher = new EventFetcher(this.l1Provider)
     const logs = (
       await eventFetcher.getEvents(
         RollupUserLogic__factory,
         t => t.filters.NodeCreated(),
         {
-          // fromBlock: Math.max(
-          //   latestBlock -
-          //     BigNumber.from(l2Network.confirmPeriodBlocks)
-          //       .add(ASSERTION_CONFIRMED_PADDING)
-          //       .toNumber(),
-          //   0
-          // ),
-          // The above does not work on a L3 where the base chain is a Arbitrum Chain because
-          // latestBlock would be in L2 blocks but confirmPeriodBlocks and ASSERTION_CONFIRMED_PADDING are in L1 blocks
-          fromBlock: 0, // dirty hack to do a full range event lookup, TODO: fix this
+          fromBlock: rollupCreatedAtBlock,
           toBlock: 'latest',
           address: rollup.address,
         }

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -337,7 +337,7 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
     const isL3 = l2Networks[l2Network.partnerChainID] !== undefined
     // The original logic does not work on a L3 where the base chain is a Arbitrum Chain because
     // latestBlock would be in L2 blocks but confirmPeriodBlocks and ASSERTION_CONFIRMED_PADDING are in L1 blocks
-    const rollupCreatedAtBlock = isL3
+    const lookupBlock = isL3
       ? (await rollup.getNodeCreationBlockForLogLookup(0)).toNumber() // dirty hack to do a full range event lookup, TODO: fix this
       : Math.max(
           latestBlock -
@@ -353,7 +353,7 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
         RollupUserLogic__factory,
         t => t.filters.NodeCreated(),
         {
-          fromBlock: rollupCreatedAtBlock,
+          fromBlock: lookupBlock,
           toBlock: 'latest',
           address: rollup.address,
         }

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -195,7 +195,9 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
     nodeNum: BigNumber,
     l2Provider: Provider
   ): Promise<ArbBlock> {
-    const createdAtBlock = await rollup.getNodeCreationBlockForLogLookup(nodeNum)
+    const createdAtBlock = await rollup.getNodeCreationBlockForLogLookup(
+      nodeNum
+    )
 
     // now get the block hash and sendroot for that node
     const eventFetcher = new EventFetcher(rollup.provider)

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -195,9 +195,11 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
     nodeNum: BigNumber,
     l2Provider: Provider
   ): Promise<ArbBlock> {
-    const createdAtBlock = await rollup.getNodeCreationBlockForLogLookup(
-      nodeNum
-    )
+    const l2Network = await getL2Network(l2Provider)
+    const isL3 = l2Networks[l2Network.partnerChainID] !== undefined
+    const createdAtBlock = isL3
+      ? await rollup.getNodeCreationBlockForLogLookup(nodeNum)
+      : (await rollup.getNode(nodeNum)).createdAtBlock
 
     // now get the block hash and sendroot for that node
     const eventFetcher = new EventFetcher(rollup.provider)

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -196,16 +196,16 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
     l2Provider: Provider
   ): Promise<ArbBlock> {
     let createdAtBlock: BigNumber
-    try {
-      if ([42161, 421613].includes((await l2Provider.getNetwork()).chainId)) {
-        // save some rpc calls as we know these network does not support the new method yet
-        createdAtBlock = (await rollup.getNode(nodeNum)).createdAtBlock
-      } else {
-        createdAtBlock = await rollup.getNodeCreationBlockForLogLookup(nodeNum)
-      }
-    } catch (e) {
-      // fallback to old method if the new method fails
+    if ([42161, 421613].includes((await l2Provider.getNetwork()).chainId)) {
+      // save some rpc calls as we know these network does not support the new method yet
       createdAtBlock = (await rollup.getNode(nodeNum)).createdAtBlock
+    } else {
+      try {
+        createdAtBlock = await rollup.getNodeCreationBlockForLogLookup(nodeNum)
+      } catch (e) {
+        // fallback to old method if the new method fails
+        createdAtBlock = (await rollup.getNode(nodeNum)).createdAtBlock
+      }
     }
 
     // now get the block hash and sendroot for that node

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -39,7 +39,7 @@ import {
   SignerOrProvider,
 } from '../dataEntities/signerOrProvider'
 import { wait } from '../utils/lib'
-import { getL2Network, l2Networks } from '../dataEntities/networks'
+import { getL2Network } from '../dataEntities/networks'
 import { NodeCreatedEvent, RollupUserLogic } from '../abi/RollupUserLogic'
 import { ArbitrumProvider } from '../utils/arbProvider'
 import { ArbBlock } from '../dataEntities/rpc'

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,14 +15,13 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@arbitrum/nitro-contracts@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@arbitrum/nitro-contracts/-/nitro-contracts-1.0.1.tgz#c9b4e6fba7375f8a2e7cacbda8248870bef2d61b"
-  integrity sha512-gNbtcWM1QkLPYs4nxvC1RnoHqcg+uk6acs11C4XRcp77vC72izpQ1+4GqMVXV6viHCNquz8posG9rButW8nHFw==
+"@arbitrum/nitro-contracts@1.1.0-alpha.0":
+  version "1.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@arbitrum/nitro-contracts/-/nitro-contracts-1.1.0-alpha.0.tgz#68f89b2c9a3baa0382fc5046d57d1e94cc8c867b"
+  integrity sha512-whJCnJLAAJiVV9Z6oWr+HHLTPdC1Od1P6f7nyp5iaOSeKvLd0/sRKrgdbmSU9nLxtPhnMFy/Dh2J8fTS7mht7Q==
   dependencies:
     "@openzeppelin/contracts" "4.5.0"
     "@openzeppelin/contracts-upgradeable" "4.5.2"
-    hardhat "^2.6.6"
     patch-package "^6.4.7"
   optionalDependencies:
     sol2uml "2.2.0"
@@ -3209,7 +3208,7 @@ handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-hardhat@^2.6.1, hardhat@^2.6.4, hardhat@^2.6.6, hardhat@^2.8.3:
+hardhat@^2.6.1, hardhat@^2.6.4, hardhat@^2.8.3:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.9.3.tgz#4759dc3c468c7d15f34334ca1be7d59b04e47b1e"
   integrity sha512-7Vw99RbYbMZ15UzegOR/nqIYIqddZXvLwJGaX5sX4G5bydILnbjmDU6g3jMKJSiArEixS3vHAEaOs5CW1JQ3hg==


### PR DESCRIPTION
This bump nitro-contracts to 1.1.0-alpha.0, fixed a abigen issue, and included orbit support.
Also released as sdk v3.2.0-alpha.1

DO NOT MERGE before the TODO is resolved