### PR TITLE
chore: improves validation for node version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,10 @@ jobs:
     env:
       TEST_PATH: /tmp/test-results
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -68,6 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -81,6 +89,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,10 @@
 {
-  "extension": ["ts"],
+  "extension": [
+    "ts"
+  ],
   "package": "./package.json",
-  "require": "ts-node/register"
+  "require": [
+    "ts-node/register",
+    "./tests/checkNodeVersion.ts"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/offchainlabs/arbitrum-sdk.git"
   },
   "engines": {
-    "node": ">=v11",
+    "node": ">=11.0.0 <17.0.0",
     "npm": "please-use-yarn",
     "yarn": ">= 1.0.0"
   },
@@ -58,6 +58,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.0.0",
     "@types/prompts": "^2.0.14",
+    "@types/semver": "^7.5.0",
     "@types/yargs": "^17.0.9",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/eslint-plugin-tslint": "^5.27.1",
@@ -78,6 +79,7 @@
     "prettier": "^2.3.2",
     "prettier-plugin-solidity": "^1.0.0-beta.17",
     "prompts": "^2.4.2",
+    "semver": "^7.5.1",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.2.1",
     "tslint": "^6.1.3",

--- a/tests/checkNodeVersion.ts
+++ b/tests/checkNodeVersion.ts
@@ -1,0 +1,8 @@
+import { satisfies } from 'semver'
+
+if (!satisfies(process.version, '>=11.0.0 <17.0.0')) {
+  console.error(
+    'Invalid Node.js version. Please use Node.js versions >=11.0.0 and <17.0.0"'
+  )
+  process.exit(1)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -4764,6 +4769,13 @@ semver@^7.0.0, semver@^7.2.1, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
When trying to run the test suite using node v18+ and using the default `nitro` setup, the tests fail with an opaque error “could not detect network” that might lead some developers down a rabbit hole of trying to fix `nitro` when the issue is in an incompatibility in the `ethers v5` stack.

I added validation to prevent using the wrong node version when installing dependencies and when running tests. This should not affect the prod SDK bundle or any consuming packages.