### PR TITLE
Fix retryableExists

### DIFF
--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -424,14 +424,13 @@ export class L1ToL2MessageReader extends L1ToL2Message {
   }
 
   private async retryableExists(): Promise<boolean> {
+    const currentTimestamp = BigNumber.from(
+      (await this.l2Provider.getBlock('latest')).timestamp
+    )
     try {
       const timeoutTimestamp = await this.getTimeout()
-      const currentTimestamp = BigNumber.from(
-        (await this.l2Provider.getBlock('latest')).timestamp
-      )
-
       // timeoutTimestamp returns the timestamp at which the retryable ticket expires
-      // it can also return 0 if the ticket l2Tx does not exist
+      // it can also return revert if the ticket l2Tx does not exist
       return currentTimestamp.lte(timeoutTimestamp)
     } catch (err) {
       return false
@@ -496,7 +495,7 @@ export class L1ToL2MessageReader extends L1ToL2Message {
   }
 
   /**
-   * How long until this message expires
+   * Timestamp at which this message expires
    * @returns
    */
   public async getTimeout(): Promise<BigNumber> {

--- a/src/lib/message/L1ToL2Message.ts
+++ b/src/lib/message/L1ToL2Message.ts
@@ -79,7 +79,7 @@ export enum EthDepositStatus {
   DEPOSITED = 2,
 }
 
-// for handling errors through in retryableExists()
+// for handling errors thrown in retryableExists()
 interface RetryableExistsError extends Error {
   code: ErrorCode
   errorName: string
@@ -442,7 +442,7 @@ export class L1ToL2MessageReader extends L1ToL2Message {
     } catch (err) {
       if (
         err instanceof Error &&
-        (err as unknown as  RetryableExistsError).code ===
+        (err as unknown as RetryableExistsError).code ===
           Logger.errors.CALL_EXCEPTION &&
         (err as unknown as RetryableExistsError).errorName === 'NoTicketWithID'
       ) {


### PR DESCRIPTION
ensure errors that aren't call reverts (i.e., RPC timeout errors) just throw / don't cause retryableExists to return false (which can lead to `status()` incorrectly reporting "expired"