### PR TITLE
feat: override L1 Provider in `L2ToL1MessageWriter`

### DIFF
--- a/src/lib/message/L2ToL1Message.ts
+++ b/src/lib/message/L2ToL1Message.ts
@@ -65,14 +65,16 @@ export class L2ToL1Message {
 
   public static fromEvent<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
-    event: L2ToL1TransactionEvent
+    event: L2ToL1TransactionEvent,
+    l1Provider?: Provider
   ): L2ToL1MessageReaderOrWriter<T>
   static fromEvent<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
-    event: L2ToL1TransactionEvent
+    event: L2ToL1TransactionEvent,
+    l1Provider?: Provider
   ): L2ToL1MessageReader | L2ToL1MessageWriter {
     return SignerProviderUtils.isSigner(l1SignerOrProvider)
-      ? new L2ToL1MessageWriter(l1SignerOrProvider, event)
+      ? new L2ToL1MessageWriter(l1SignerOrProvider, event, l1Provider)
       : new L2ToL1MessageReader(l1SignerOrProvider, event)
   }
 
@@ -262,17 +264,26 @@ export class L2ToL1MessageWriter extends L2ToL1MessageReader {
   private readonly classicWriter?: classic.L2ToL1MessageWriterClassic
   private readonly nitroWriter?: nitro.L2ToL1MessageWriterNitro
 
-  constructor(l1Signer: Signer, event: L2ToL1TransactionEvent) {
-    super(l1Signer.provider!, event)
+  constructor(
+    l1Signer: Signer,
+    event: L2ToL1TransactionEvent,
+    l1Provider?: Provider
+  ) {
+    super(l1Provider ?? l1Signer.provider!, event)
 
     if (this.isClassic(event)) {
       this.classicWriter = new classic.L2ToL1MessageWriterClassic(
         l1Signer,
         event.batchNumber,
-        event.indexInBatch
+        event.indexInBatch,
+        l1Provider
       )
     } else {
-      this.nitroWriter = new nitro.L2ToL1MessageWriterNitro(l1Signer, event)
+      this.nitroWriter = new nitro.L2ToL1MessageWriterNitro(
+        l1Signer,
+        event,
+        l1Provider
+      )
     }
   }
 

--- a/src/lib/message/L2ToL1Message.ts
+++ b/src/lib/message/L2ToL1Message.ts
@@ -63,6 +63,13 @@ export class L2ToL1Message {
     )
   }
 
+  /**
+   * Instantiates a new `L2ToL1MessageWriter` or `L2ToL1MessageReader` object.
+   *
+   * @param {SignerOrProvider} l1SignerOrProvider Signer or provider to be used for executing or reading the L2-to-L1 message.
+   * @param {L2ToL1TransactionEvent} event The event containing the data of the L2-to-L1 message.
+   * @param {Provider} [l1Provider] Optional. Used to override the Provider which is attached to `l1SignerOrProvider` in case you need more control. This will be a required parameter in a future major version update.
+   */
   public static fromEvent<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
     event: L2ToL1TransactionEvent,
@@ -264,6 +271,13 @@ export class L2ToL1MessageWriter extends L2ToL1MessageReader {
   private readonly classicWriter?: classic.L2ToL1MessageWriterClassic
   private readonly nitroWriter?: nitro.L2ToL1MessageWriterNitro
 
+  /**
+   * Instantiates a new `L2ToL1MessageWriter` object.
+   *
+   * @param {Signer} l1Signer The signer to be used for executing the L2-to-L1 message.
+   * @param {L2ToL1TransactionEvent} event The event containing the data of the L2-to-L1 message.
+   * @param {Provider} [l1Provider] Optional. Used to override the Provider which is attached to `l1Signer` in case you need more control. This will be a required parameter in a future major version update.
+   */
   constructor(
     l1Signer: Signer,
     event: L2ToL1TransactionEvent,

--- a/src/lib/message/L2ToL1MessageClassic.ts
+++ b/src/lib/message/L2ToL1MessageClassic.ts
@@ -114,6 +114,14 @@ export class L2ToL1MessageClassic {
     this.indexInBatch = indexInBatch
   }
 
+  /**
+   * Instantiates a new `L2ToL1MessageWriterClassic` or `L2ToL1MessageReaderClassic` object.
+   *
+   * @param {SignerOrProvider} l1SignerOrProvider Signer or provider to be used for executing or reading the L2-to-L1 message.
+   * @param {BigNumber} batchNumber The number of the batch containing the L2-to-L1 message.
+   * @param {BigNumber} indexInBatch The index of the L2-to-L1 message within the batch.
+   * @param {Provider} [l1Provider] Optional. Used to override the Provider which is attached to `l1SignerOrProvider` in case you need more control. This will be a required parameter in a future major version update.
+   */
   public static fromBatchNumber<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
     batchNumber: BigNumber,
@@ -373,6 +381,14 @@ export class L2ToL1MessageReaderClassic extends L2ToL1MessageClassic {
  * Provides read and write access for classic l2-to-l1-messages
  */
 export class L2ToL1MessageWriterClassic extends L2ToL1MessageReaderClassic {
+  /**
+   * Instantiates a new `L2ToL1MessageWriterClassic` object.
+   *
+   * @param {Signer} l1Signer The signer to be used for executing the L2-to-L1 message.
+   * @param {BigNumber} batchNumber The number of the batch containing the L2-to-L1 message.
+   * @param {BigNumber} indexInBatch The index of the L2-to-L1 message within the batch.
+   * @param {Provider} [l1Provider] Optional. Used to override the Provider which is attached to `l1Signer` in case you need more control. This will be a required parameter in a future major version update.
+   */
   constructor(
     private readonly l1Signer: Signer,
     batchNumber: BigNumber,

--- a/src/lib/message/L2ToL1MessageClassic.ts
+++ b/src/lib/message/L2ToL1MessageClassic.ts
@@ -117,18 +117,21 @@ export class L2ToL1MessageClassic {
   public static fromBatchNumber<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
     batchNumber: BigNumber,
-    indexInBatch: BigNumber
+    indexInBatch: BigNumber,
+    l1Provider?: Provider
   ): L2ToL1MessageReaderOrWriterClassic<T>
   public static fromBatchNumber<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
     batchNumber: BigNumber,
-    indexInBatch: BigNumber
+    indexInBatch: BigNumber,
+    l1Provider?: Provider
   ): L2ToL1MessageReaderClassic | L2ToL1MessageWriterClassic {
     return SignerProviderUtils.isSigner(l1SignerOrProvider)
       ? new L2ToL1MessageWriterClassic(
           l1SignerOrProvider,
           batchNumber,
-          indexInBatch
+          indexInBatch,
+          l1Provider
         )
       : new L2ToL1MessageReaderClassic(
           l1SignerOrProvider,
@@ -373,9 +376,10 @@ export class L2ToL1MessageWriterClassic extends L2ToL1MessageReaderClassic {
   constructor(
     private readonly l1Signer: Signer,
     batchNumber: BigNumber,
-    indexInBatch: BigNumber
+    indexInBatch: BigNumber,
+    l1Provider?: Provider
   ) {
-    super(l1Signer.provider!, batchNumber, indexInBatch)
+    super(l1Provider ?? l1Signer.provider!, batchNumber, indexInBatch)
   }
 
   /**

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -67,6 +67,13 @@ const ASSERTION_CONFIRMED_PADDING = 20
 export class L2ToL1MessageNitro {
   protected constructor(public readonly event: EventArgs<L2ToL1TxEvent>) {}
 
+  /**
+   * Instantiates a new `L2ToL1MessageWriterNitro` or `L2ToL1MessageReaderNitro` object.
+   *
+   * @param {SignerOrProvider} l1SignerOrProvider Signer or provider to be used for executing or reading the L2-to-L1 message.
+   * @param {EventArgs<L2ToL1TxEvent>} event The event containing the data of the L2-to-L1 message.
+   * @param {Provider} [l1Provider] Optional. Used to override the Provider which is attached to `l1SignerOrProvider` in case you need more control. This will be a required parameter in a future major version update.
+   */
   public static fromEvent<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
     event: EventArgs<L2ToL1TxEvent>,
@@ -403,6 +410,13 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
  * Provides read and write access for nitro l2-to-l1-messages
  */
 export class L2ToL1MessageWriterNitro extends L2ToL1MessageReaderNitro {
+  /**
+   * Instantiates a new `L2ToL1MessageWriterNitro` object.
+   *
+   * @param {Signer} l1Signer The signer to be used for executing the L2-to-L1 message.
+   * @param {EventArgs<L2ToL1TxEvent>} event The event containing the data of the L2-to-L1 message.
+   * @param {Provider} [l1Provider] Optional. Used to override the Provider which is attached to `l1Signer` in case you need more control. This will be a required parameter in a future major version update.
+   */
   constructor(
     private readonly l1Signer: Signer,
     event: EventArgs<L2ToL1TxEvent>,

--- a/src/lib/message/L2ToL1MessageNitro.ts
+++ b/src/lib/message/L2ToL1MessageNitro.ts
@@ -69,14 +69,16 @@ export class L2ToL1MessageNitro {
 
   public static fromEvent<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
-    event: EventArgs<L2ToL1TxEvent>
+    event: EventArgs<L2ToL1TxEvent>,
+    l1Provider?: Provider
   ): L2ToL1MessageReaderOrWriterNitro<T>
   public static fromEvent<T extends SignerOrProvider>(
     l1SignerOrProvider: T,
-    event: EventArgs<L2ToL1TxEvent>
+    event: EventArgs<L2ToL1TxEvent>,
+    l1Provider?: Provider
   ): L2ToL1MessageReaderNitro | L2ToL1MessageWriterNitro {
     return SignerProviderUtils.isSigner(l1SignerOrProvider)
-      ? new L2ToL1MessageWriterNitro(l1SignerOrProvider, event)
+      ? new L2ToL1MessageWriterNitro(l1SignerOrProvider, event, l1Provider)
       : new L2ToL1MessageReaderNitro(l1SignerOrProvider, event)
   }
 
@@ -403,9 +405,10 @@ export class L2ToL1MessageReaderNitro extends L2ToL1MessageNitro {
 export class L2ToL1MessageWriterNitro extends L2ToL1MessageReaderNitro {
   constructor(
     private readonly l1Signer: Signer,
-    event: EventArgs<L2ToL1TxEvent>
+    event: EventArgs<L2ToL1TxEvent>,
+    l1Provider?: Provider
   ) {
-    super(l1Signer.provider!, event)
+    super(l1Provider ?? l1Signer.provider!, event)
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/OffchainLabs/arbitrum-sdk/issues/286.

This PR is additive only. It adds an optional `l1Provider` param when instantiating message writers, allowing you to override the L1 provider which is set by default as `l1Signer.provider`.

Reason behind the change was that in the Bridge UI, a particular version bump of `wagmi` changed the shape of the provider that's attached to the signer for some wallets, and some static calls were failing. Allowing us to pass in a provider of our own gives us more control.