### PR TITLE
feat: adds global config experimental flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,3 +62,7 @@ export {
 } from './lib/dataEntities/retryableData'
 
 export { Address } from './lib/dataEntities/address'
+export {
+  enableExperimentalFeatures,
+  experimentalFeaturesEnabled,
+} from './lib/utils/globalConfig'

--- a/src/lib/utils/globalConfig.ts
+++ b/src/lib/utils/globalConfig.ts
@@ -1,0 +1,11 @@
+export const globalConfig = {
+  experimentalFeaturesEnabled: false,
+}
+
+export const enableExperimentalFeatures = () => {
+  globalConfig.experimentalFeaturesEnabled = true
+}
+
+export const experimentalFeaturesEnabled = () => {
+  return globalConfig.experimentalFeaturesEnabled
+}


### PR DESCRIPTION
In order to be able to ship experimental features for broader testing among consuming applications, we've added a global config object with an experimental flag that would be used like this:

```ts
import {
  enableExperimentalFeatures,
  experimentalFeaturesEnabled
} from '@arbitrum/sdk'


// To enable experimental features:
enableExperimentalFeatures()


// To check if experimental features are enabled anywhere in the application
if (experimentalFeaturesEnabled()){
  // do experimental things
}
```

I did it this way to limit access to the global config object as much as possible. 