### PR TITLE
chore: update advisories allowlist

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -117,6 +117,12 @@
     // Undici's cookie header not cleared on cross-origin redirect in fetch
     // from: hardhat>undici
     // hardhat is only used in dev
-    "GHSA-wqq4-5wpv-mx2g"
+    "GHSA-wqq4-5wpv-mx2g",
+    // https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
+    // axios inadvertently reveals the confidential XSRF-TOKEN stored in cookies
+    // we don't use cookies with axios in the sdk
+    // from: @arbitrum/nitro-contracts>sol2uml>axios
+    // from: axios
+    "GHSA-wf5p-g6vw-rhxx"
   ]
 }


### PR DESCRIPTION
There was a security advisory for Axios that let attackers obtain secrets in cookies. 

We do use axios in the `deployStandard` script, but only to fetch. It's also used in the `nitro-contracts` dependency, but only for `sol2uml` which is dev-only so not an issue for this vulnerability.

Therefore, this advisory was added to the allowlist.