### PR TITLE
fix: use L2GatewayRouter abi

### DIFF
--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -907,7 +907,7 @@ export class AdminErc20Bridger extends Erc20Bridger {
     const eventFetcher = new EventFetcher(l2Provider)
     return (
       await eventFetcher.getEvents(
-        L1GatewayRouter__factory,
+        L2GatewayRouter__factory,
         t => t.filters.GatewaySet(),
         { ...filter, address: l2GatewayRouterAddress }
       )


### PR DESCRIPTION
Small fix. 

`L2GatewayRouter__factory` needs to be used instead of `L1GatewayRouter__factory`  in `getL2GatewaySetEvents`.