### PR TITLE
Deploy both L1<->L2 and L2<->L3 token bridges in `testSetup`

### DIFF
--- a/scripts/deployBridge.ts
+++ b/scripts/deployBridge.ts
@@ -170,7 +170,8 @@ export const deployErc20L2 = async (deployer: Signer) => {
 export const deployErc20AndInit = async (
   l1Signer: Signer,
   l2Signer: Signer,
-  inboxAddress: string
+  inboxAddress: string,
+  l1WethOverride?: string
 ) => {
   console.log('deploying l1')
   const l1 = await deployErc20L1(l1Signer)
@@ -202,14 +203,14 @@ export const deployErc20AndInit = async (
       'WETH',
       18,
       l2.wethGateway.address,
-      l1.weth.address
+      l1WethOverride || l1.weth.address
     )
   ).wait()
   await (
     await l2.wethGateway.initialize(
       l1.wethGateway.address,
       l2.router.address,
-      l1.weth.address,
+      l1WethOverride || l1.weth.address,
       l2.weth.address
     )
   ).wait()
@@ -247,7 +248,7 @@ export const deployErc20AndInit = async (
       l2.wethGateway.address,
       l1.router.address,
       inboxAddress,
-      l1.weth.address,
+      l1WethOverride || l1.weth.address,
       l2.weth.address
     )
   ).wait()

--- a/scripts/genNetwork.ts
+++ b/scripts/genNetwork.ts
@@ -5,7 +5,11 @@ async function main() {
   const setup = await testSetup(true)
   fs.writeFileSync(
     'localNetwork.json',
-    JSON.stringify({ l1Network: setup.l1Network, l2Network: setup.l2Network }, null, 2)
+    JSON.stringify(
+      { l1Network: setup.l1Network, l2Network: setup.l2Network },
+      null,
+      2
+    )
   )
   console.log('localnetwork.json updated')
 }

--- a/scripts/genNetwork.ts
+++ b/scripts/genNetwork.ts
@@ -1,24 +1,11 @@
-import { ethers } from 'ethers'
-import { setupNetworks, config, getSigner } from './testSetup'
+import { testSetup } from './testSetup'
 import * as fs from 'fs'
 
 async function main() {
-  const ethProvider = new ethers.providers.JsonRpcProvider(config.ethUrl)
-  const arbProvider = new ethers.providers.JsonRpcProvider(config.arbUrl)
-
-  const ethDeployer = getSigner(ethProvider, config.ethKey)
-  const arbDeployer = getSigner(arbProvider, config.arbKey)
-
-  const { l1Network, l2Network } = await setupNetworks(
-    ethDeployer,
-    arbDeployer,
-    config.ethUrl,
-    config.arbUrl
-  )
-
+  const setup = await testSetup(true)
   fs.writeFileSync(
     'localNetwork.json',
-    JSON.stringify({ l1Network, l2Network }, null, 2)
+    JSON.stringify({ l1Network: setup.l1Network, l2Network: setup.l2Network }, null, 2)
   )
   console.log('localnetwork.json updated')
 }

--- a/scripts/testSetup.ts
+++ b/scripts/testSetup.ts
@@ -207,7 +207,7 @@ const getL1NetworkForOrbit = async (): Promise<{
 }
 
 /**
- * Gets the L3 network (as defined in the environment)
+ * Gets the L3 Orbit network and its parent network
  */
 const getOrbitNetwork = async (): Promise<{
   customL1Network: L2Network

--- a/scripts/testSetup.ts
+++ b/scripts/testSetup.ts
@@ -342,7 +342,7 @@ export const setupNetworks = async (
     },
   }
 
-  // in case of L3, we only need to add the L3, as L1 and L2 were registered inside "setupL1NetworkForOrbit"
+  // in case of L3, we only need to add the L3, as L1 and L2 were registered in a previous call to setupNetworks
   // register the network with the newly deployed token bridge contracts
   if (shouldSetupOrbit) {
     addCustomNetwork({ customL2Network: l2Network })

--- a/scripts/testSetup.ts
+++ b/scripts/testSetup.ts
@@ -197,7 +197,6 @@ const getL1NetworkForOrbit = async (): Promise<{
   const deploymentData = getDeploymentData()
   const parsedDeploymentData = JSON.parse(deploymentData) as DeploymentData
 
-
   const l2Network = await getCustomOrbitNetwork(
     parsedDeploymentData,
     l1Provider,
@@ -378,7 +377,9 @@ export const getSigner = (provider: JsonRpcProvider, key?: string) => {
   else return provider.getSigner(0)
 }
 
-export const testSetup = async (ignoreLocalNetworkJson?: boolean): Promise<{
+export const testSetup = async (
+  ignoreLocalNetworkJson?: boolean
+): Promise<{
   l1Network: L1Network | L2Network
   l2Network: L2Network
   l1Signer: Signer
@@ -432,17 +433,16 @@ export const testSetup = async (ignoreLocalNetworkJson?: boolean): Promise<{
 
         addCustomNetwork({
           customL1Network: ethLocal,
-          customL2Network: l1Network
+          customL2Network: l1Network,
         })
-        
-        addCustomNetwork({ 
-          customL2Network: l2Network 
+
+        addCustomNetwork({
+          customL2Network: l2Network,
         })
 
         setL1Network = l1Network
         setL2Network = l2Network
-      }
-      else {
+      } else {
         const { l1Network, l2Network } = file as {
           l1Network: L1Network
           l2Network: L2Network

--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -686,7 +686,7 @@ export class Erc20Bridger extends AssetBridger<
         const isWeth = await this.isWethGateway(l1GatewayAddress, l1Provider)
 
         // measured 157421 - add some padding
-        return isWeth ? BigNumber.from(180000) : BigNumber.from(160000)
+        return isWeth ? BigNumber.from(190000) : BigNumber.from(160000)
       },
     }
   }


### PR DESCRIPTION
the weth withdrawal gas limit had to be raised because the weth contract has changed on the parent chain when testing orbit