### PR TITLE
fixed test case

### DIFF
--- a/tests/integration/eth.test.ts
+++ b/tests/integration/eth.test.ts
@@ -96,8 +96,8 @@ describe('Ether', async () => {
 
     expect(rec.status).to.equal(1, 'eth deposit L1 txn failed')
     const finalInboxBalance = await l1Signer.provider!.getBalance(inboxAddress)
-    expect(
-      initialInboxBalance.add(ethToDeposit).eq(finalInboxBalance),
+    expect(initialInboxBalance.add(ethToDeposit)).to.eq(
+      finalInboxBalance,
       'balance failed to update after eth deposit'
     )
 


### PR DESCRIPTION
Fixed `expect` and now it fails.

```
$ mocha --parallel tests/integration/eth.test.ts --timeout 30000 --bail


  Ether
    ✔ transfers ether on l2 (190ms)
    1) deposits ether


  1 passing (11s)
  1 failing

  1) Ether
       deposits ether:

      balance failed to update after eth deposit
      + expected - actual

       {
      -  "_hex": "0xb5e620f48000"
      +  "_hex": "0x00"
         "_isBigNumber": true
       }
      
      at Context.<anonymous> (tests/integration/eth.test.ts:99:54)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

