### PR TITLE
Ha/informative gas estimator error

### DIFF
--- a/src/lib/dataEntities/retryableData.ts
+++ b/src/lib/dataEntities/retryableData.ts
@@ -114,11 +114,16 @@ export class RetryableDataTools {
   public static tryParseError(
     ethersJsErrorOrData: Error | { errorData: string } | string
   ): RetryableData | null {
-    const errorData =
-      typeof ethersJsErrorOrData === 'string'
-        ? ethersJsErrorOrData
-        : this.tryGetErrorData(ethersJsErrorOrData)
-    if (!errorData) return null
-    return errorInterface.parseError(errorData).args as unknown as RetryableData
+    try {
+      const errorData =
+        typeof ethersJsErrorOrData === 'string'
+          ? ethersJsErrorOrData
+          : this.tryGetErrorData(ethersJsErrorOrData)
+      if (!errorData) return null
+      return errorInterface.parseError(errorData)
+        .args as unknown as RetryableData
+    } catch {
+      return null
+    }
   }
 }

--- a/src/lib/message/L1ToL2MessageGasEstimator.ts
+++ b/src/lib/message/L1ToL2MessageGasEstimator.ts
@@ -306,14 +306,14 @@ export class L1ToL2MessageGasEstimator {
     })
 
     let retryable: RetryableData | null
+    const res = await l1Provider.call({
+      to: to,
+      data: nullData,
+      value: value,
+      from: from,
+    })
     try {
       // get retryable data from the null call
-      const res = await l1Provider.call({
-        to: to,
-        data: nullData,
-        value: value,
-        from: from,
-      })
       retryable = RetryableDataTools.tryParseError(res)
       if (!isDefined(retryable)) {
         throw new ArbSdkError(`No retryable data found in error: ${res}`)
@@ -324,7 +324,7 @@ export class L1ToL2MessageGasEstimator {
       // behaviour and we dont pick up on it
       retryable = RetryableDataTools.tryParseError(err as Error)
       if (!isDefined(retryable)) {
-        throw new ArbSdkError('No retryable data found in error', err as Error)
+        throw new ArbSdkError(`No retryable data found in error: ${res}`, err as Error)
       }
     }
 

--- a/src/lib/message/L1ToL2MessageGasEstimator.ts
+++ b/src/lib/message/L1ToL2MessageGasEstimator.ts
@@ -306,14 +306,14 @@ export class L1ToL2MessageGasEstimator {
     })
 
     let retryable: RetryableData | null
-    const res = await l1Provider.call({
-      to: to,
-      data: nullData,
-      value: value,
-      from: from,
-    })
     try {
       // get retryable data from the null call
+      const res = await l1Provider.call({
+        to: to,
+        data: nullData,
+        value: value,
+        from: from,
+      })
       retryable = RetryableDataTools.tryParseError(res)
       if (!isDefined(retryable)) {
         throw new ArbSdkError(`No retryable data found in error: ${res}`)
@@ -324,7 +324,7 @@ export class L1ToL2MessageGasEstimator {
       // behaviour and we dont pick up on it
       retryable = RetryableDataTools.tryParseError(err as Error)
       if (!isDefined(retryable)) {
-        throw new ArbSdkError(`No retryable data found in error: ${res}`, err as Error)
+        throw new ArbSdkError('No retryable data found in error', err as Error)
       }
     }
 


### PR DESCRIPTION
stack trace before:
```
Error: No retryable data found in error
      at ...
  Caused By: Error: no matching error (argument="sighash", value="0x08c379a0", code=INVALID_ARGUMENT, version=abi/5.7.0)
      at ...
```

stack trace after:
```
Error: No retryable data found in error
      at ...
  Caused By: Error: No retryable data found in error: 0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001d45524332303a20696e73756666696369656e7420616c6c6f77616e6365000000
      at ...
```