### PR TITLE
chore: fix audit failure

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -71,6 +71,14 @@
     // we don't use oz/merkle-trees anywhere
     // from @arbitrum/nitro-contracts>@offchainlabs/upgrade-executor>@openzeppelin/contracts-upgradeable
     // from @arbitrum/nitro-contracts>@offchainlabs/upgrade-executor>@openzeppelin/contracts
-    "GHSA-wprv-93r4-jj2p"
+    "GHSA-wprv-93r4-jj2p",
+    // https://github.com/advisories/GHSA-9vx6-7xxf-x967
+    // OpenZeppelin Contracts base64 encoding may read from potentially dirty memory
+    // we don't use the base64 functions
+    // from: @arbitrum/nitro-contracts>@openzeppelin/contracts-upgradeable
+    // from: @arbitrum/token-bridge-contracts>@openzeppelin/contracts-upgradeable
+    // from: @arbitrum/nitro-contracts>@openzeppelin/contracts
+    // from: @arbitrum/token-bridge-contracts>@openzeppelin/contracts
+    "GHSA-9vx6-7xxf-x967"
   ]
 }


### PR DESCRIPTION
There's a vulnerability with base64 encoding in OpenZepplin. We don't use the base64 encoding functions, and OpenZepplin is used at dev-time only. 