### PR TITLE
chore: update testnode version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          nitro-testnode-ref: master
+          nitro-testnode-ref: release
           l3-node: ${{ matrix.orbit-test == '1' }}
           args: ${{ matrix.custom-fee == '1' && '--l3-fee-token' || '' }}
 


### PR DESCRIPTION
a change in the `nitro-testnode` repo has broken tests here. 

We should probably rely on the `release` branch for testing here so changes to `nitro-testnode` that aren't released don't break our builds.