### PR TITLE
feat: update behaviour for registering custom networks

### DIFF
--- a/scripts/testSetup.ts
+++ b/scripts/testSetup.ts
@@ -27,7 +27,7 @@ import {
   ArbitrumNetwork,
   mapL2NetworkToArbitrumNetwork,
   getArbitrumNetwork,
-  addCustomArbitrumNetwork,
+  registerCustomArbitrumNetwork,
 } from '../src/lib/dataEntities/networks'
 import { Signer } from 'ethers'
 import { AdminErc20Bridger } from '../src/lib/assetBridger/erc20Bridger'
@@ -103,9 +103,7 @@ export const testSetup = async (): Promise<{
     // the networks havent been added yet
     // check if theres an existing network available
     const { l2Network: childChain } = getLocalNetworksFromFile()
-
-    addCustomArbitrumNetwork(childChain)
-    setChildChain = childChain
+    setChildChain = registerCustomArbitrumNetwork(childChain)
   }
 
   const erc20Bridger = new Erc20Bridger(setChildChain)

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,9 @@ export {
   getArbitrumNetwork,
   ArbitrumNetworkInformationFromRollup,
   getArbitrumNetworkInformationFromRollup,
-  addCustomArbitrumNetwork,
-  addDefaultLocalNetwork,
   getChildrenForNetwork,
+  registerCustomArbitrumNetwork,
+  addDefaultLocalNetwork,
 } from './lib/dataEntities/networks'
 export { InboxTools } from './lib/inbox/inbox'
 export { EventFetcher } from './lib/utils/eventFetcher'

--- a/src/lib/dataEntities/networks.ts
+++ b/src/lib/dataEntities/networks.ts
@@ -361,18 +361,39 @@ export async function getArbitrumNetworkInformationFromRollup(
 }
 
 /**
- * Registers a custom Arbitrum chain (L2 or L3).
+ * Registers a custom Arbitrum network.
  *
- * @param network
+ * @param network {@link ArbitrumNetwork} to be registered
+ * @param options Additional options
+ * @param options.throwIfAlreadyRegistered Whether or not the function should throw if the network is already registered, defaults to `false`
  */
-export const addCustomArbitrumNetwork = (network: ArbitrumNetwork): void => {
+export function registerCustomArbitrumNetwork(
+  network: ArbitrumNetwork,
+  options?: { throwIfAlreadyRegistered?: boolean }
+): ArbitrumNetwork {
+  const throwIfAlreadyRegistered = options?.throwIfAlreadyRegistered ?? false
+
+  if (!network.isCustom) {
+    throw new ArbSdkError(
+      `Custom network ${network.chainId} must have isCustom flag set to true`
+    )
+  }
+
   if (typeof networks[network.chainId] !== 'undefined') {
-    throw new Error(`Network ${network.chainId} already included`)
+    const message = `Network ${network.chainId} already included`
+
+    if (throwIfAlreadyRegistered) {
+      throw new ArbSdkError(message)
+    }
+
+    console.warn(message)
   }
 
   // store the network with the rest of the networks
   networks[network.chainId] = network
   l2Networks = getArbitrumChains()
+
+  return network
 }
 
 /**
@@ -412,9 +433,7 @@ export const addDefaultLocalNetwork = (): ArbitrumNetwork => {
     },
   }
 
-  addCustomArbitrumNetwork(defaultLocalL2Network)
-
-  return defaultLocalL2Network
+  return registerCustomArbitrumNetwork(defaultLocalL2Network)
 }
 
 /**

--- a/tests/unit/network.test.ts
+++ b/tests/unit/network.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import {
   resetNetworksToDefault,
-  addCustomArbitrumNetwork,
+  registerCustomArbitrumNetwork,
   getArbitrumNetwork,
   l2Networks as arbitrumNetworks,
   getChildrenForNetwork,
@@ -32,7 +32,7 @@ describe('Networks', async () => {
         isCustom: true,
       } as const
 
-      addCustomArbitrumNetwork(customArbitrumNetwork)
+      registerCustomArbitrumNetwork(customArbitrumNetwork)
 
       expect(await getArbitrumNetwork(mockL2ChainId)).to.be.ok
 
@@ -54,7 +54,7 @@ describe('Networks', async () => {
         isCustom: true,
       } as const
 
-      addCustomArbitrumNetwork(customArbitrumNetwork)
+      registerCustomArbitrumNetwork(customArbitrumNetwork)
 
       expect(await getArbitrumNetwork(mockL3ChainId)).to.be.ok
 
@@ -93,7 +93,7 @@ describe('Networks', async () => {
         isCustom: true,
       } as const
 
-      addCustomArbitrumNetwork(customL3Network)
+      registerCustomArbitrumNetwork(customL3Network)
 
       const l3Network = await getArbitrumNetwork(mockL3ChainId)
       expect(l3Network.chainId).to.be.eq(mockL3ChainId)


### PR DESCRIPTION
- Renamed `addCustomNetwork` to `registerCustomArbitrumNetwork` because I feel that's the language everyone uses anyway when talking about custom networks in the SDK
- Added back the check for `isCustom`
- The function no longer throws if a network is already registered, but you can make it do so with `options.throwIfAlreadyRegistered`
- The function now returns the registered network because it's convenient