### PR TITLE
fix: inconsistent `erc20L1Address` casing

### DIFF
--- a/src/lib/assetBridger/erc20Bridger.ts
+++ b/src/lib/assetBridger/erc20Bridger.ts
@@ -127,7 +127,7 @@ export interface Erc20WithdrawParams extends EthWithdrawParams {
   /**
    * L1 address of the token ERC20 contract
    */
-  erc20l1Address: string
+  erc20L1Address: string
 }
 
 export type L1ToL2TxReqAndSignerProvider = L1ToL2TransactionRequest & {
@@ -772,7 +772,7 @@ export class Erc20Bridger extends AssetBridger<
           ): string
         }
       ).encodeFunctionData('outboundTransfer(address,address,uint256,bytes)', [
-        params.erc20l1Address,
+        params.erc20L1Address,
         to,
         params.amount,
         '0x',
@@ -796,7 +796,7 @@ export class Erc20Bridger extends AssetBridger<
         }
 
         const l1GatewayAddress = await this.getL1GatewayAddress(
-          params.erc20l1Address,
+          params.erc20L1Address,
           l1Provider
         )
 

--- a/tests/integration/testHelpers.ts
+++ b/tests/integration/testHelpers.ts
@@ -88,7 +88,7 @@ export const mineUntilStop = async (
 export const withdrawToken = async (params: WithdrawalParams) => {
   const withdrawalParams = await params.erc20Bridger.getWithdrawalRequest({
     amount: params.amount,
-    erc20l1Address: params.l1Token.address,
+    erc20L1Address: params.l1Token.address,
     destinationAddress: await params.l2Signer.getAddress(),
     from: await params.l2Signer.getAddress(),
   })
@@ -99,7 +99,7 @@ export const withdrawToken = async (params: WithdrawalParams) => {
   const withdrawRes = await params.erc20Bridger.withdraw({
     destinationAddress: await params.l2Signer.getAddress(),
     amount: params.amount,
-    erc20l1Address: params.l1Token.address,
+    erc20L1Address: params.l1Token.address,
     l2Signer: params.l2Signer,
   })
   const withdrawRec = await withdrawRes.wait()
@@ -372,7 +372,7 @@ export const depositToken = async ({
   )
   expect(l1Erc20Addr).to.equal(
     l1TokenAddress,
-    'getERC20L1Address/getERC20L2Address failed with proper token address'
+    'getL1ERC20Address/getL2ERC20Address failed with proper token address'
   )
 
   const tokenBalL2After = await l2Token.balanceOf(


### PR DESCRIPTION
Does what it says on the box - fixes inconsistent casing of `erc20L1Address` between `Erc20DepositParams` and `Erc20WithdrawParams`