### PR TITLE
fix: bump new advisory ws to patched version

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -99,6 +99,11 @@
     // Uncontrolled resource consumption in braces
     // eslint and hardhat dependency, only used in dev
     // from: hardhat>braces & eslint>braces
-    "GHSA-grv7-fg5c-xmjg"
+    "GHSA-grv7-fg5c-xmjg",
+    // https://github.com/advisories/GHSA-3787-6prv-h9w3
+    // Undici proxy-authorization header not cleared on cross-origin redirect in fetch
+    // hardhat requests are only done during development
+    // from: hardhat>undici
+    "GHSA-3787-6prv-h9w3"
   ]
 }

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -4,14 +4,6 @@
   "allowlist": [
     // Open Zepplin
     ////////////
-    // https://github.com/advisories/GHSA-88g8-f5mf-f5rj
-    // Improper Initialization in OpenZeppelin
-    // Initialiser can be re-entered. We've checked and aren't currently vulnerable.
-    "GHSA-88g8-f5mf-f5rj",
-    // https://github.com/advisories/GHSA-9c22-pwxw-p6hx
-    // Initializer reentrancy may lead to double initialization
-    // Initialiser can be re-entered. We've checked and aren't currently vulnerable.
-    "GHSA-9c22-pwxw-p6hx",
     // https://github.com/advisories/GHSA-4g63-c64m-25w9
     // OpenZeppelin Contracts's SignatureChecker may revert on invalid EIP-1271 signers
     // We dont use EIP-1271
@@ -60,12 +52,6 @@
     // from @arbitrum/nitro-contracts>@openzeppelin/contracts
     // We don't use ERC2771Context
     "GHSA-g4vp-m682-qqmp",
-    // https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
-    // axios inadvertently reveals the confidential XSRF-TOKEN stored in cookies
-    // we don't use cookies with axios in the sdk
-    // from: @arbitrum/nitro-contracts>sol2uml>axios
-    // from: axios
-    "GHSA-wf5p-g6vw-rhxx",
     // https://github.com/advisories/GHSA-wprv-93r4-jj2p
     // OpenZeppelin Contracts using MerkleProof multiproofs may allow proving arbitrary leaves for specific trees
     // we don't use oz/merkle-trees anywhere

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -99,11 +99,6 @@
     // Uncontrolled resource consumption in braces
     // eslint and hardhat dependency, only used in dev
     // from: hardhat>braces & eslint>braces
-    "GHSA-grv7-fg5c-xmjg",
-    // https://github.com/advisories/GHSA-3787-6prv-h9w3
-    // Undici proxy-authorization header not cleared on cross-origin redirect in fetch
-    // hardhat requests are only done during development
-    // from: hardhat>undici
-    "GHSA-3787-6prv-h9w3"
+    "GHSA-grv7-fg5c-xmjg"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "dist/**/*"
   ],
   "resolutions": {
-    "lodash.pick": "https://github.com/lodash/lodash/archive/refs/tags/4.17.21.tar.gz"
+    "lodash.pick": "https://github.com/lodash/lodash/archive/refs/tags/4.17.21.tar.gz",
+    "**/@ethersproject/providers/ws": "7.5.10",
+    "**/hardhat/ws": "7.5.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5731,15 +5731,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@7.4.6:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
-
-ws@^7.4.6:
-  version "7.5.9"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
-  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+ws@7.4.6, ws@7.5.10, ws@^7.4.6:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
- Bump ws versions
- Add GHSA-3787-6prv-h9w3 to ignored audit error