### PR TITLE
fix InboxTools method: GetForceIncludableBlockRange

### DIFF
--- a/src/lib/inbox/inbox.ts
+++ b/src/lib/inbox/inbox.ts
@@ -215,12 +215,7 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          ) as [BigNumber, BigNumber, BigNumber, BigNumber] & {
-            delayBlocks: BigNumber
-            futureBlocks: BigNumber
-            delaySeconds: BigNumber
-            futureSeconds: BigNumber
-          }, //casted until sync with @arbitrum/nitro-contracts 
+          ) as Awaited<ReturnType<SequencerInbox['maxTimeVariation']>>, //casted until sync with @arbitrum/nitro-contracts 
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),

--- a/src/lib/inbox/inbox.ts
+++ b/src/lib/inbox/inbox.ts
@@ -215,7 +215,7 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          )[0],
+          ),
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),

--- a/src/lib/inbox/inbox.ts
+++ b/src/lib/inbox/inbox.ts
@@ -215,7 +215,7 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          ) as Awaited<ReturnType<SequencerInbox['maxTimeVariation']>>, //casted until sync with @arbitrum/nitro-contracts 
+          ) as Awaited<ReturnType<SequencerInbox['maxTimeVariation']>>,
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),

--- a/src/lib/inbox/inbox.ts
+++ b/src/lib/inbox/inbox.ts
@@ -215,7 +215,12 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          ),
+          ) as [BigNumber, BigNumber, BigNumber, BigNumber] & {
+            delayBlocks: BigNumber
+            futureBlocks: BigNumber
+            delaySeconds: BigNumber
+            futureSeconds: BigNumber
+          }, //casted until sync with @arbitrum/nitro-contracts 
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),


### PR DESCRIPTION
Fixes decode of **SequencerInbox: maxTimeVariaton** contract call.

Removed failing accesor since maxTimeVariation returns a tuple, accesing the first value was breaking on runtime.