### PR TITLE
Docs: link fixes

### DIFF
--- a/docs/1-introduction.mdx
+++ b/docs/1-introduction.mdx
@@ -100,7 +100,7 @@ Arbitrum SDK comes pre-configured for Mainnet and Sepolia, and their Arbitrum co
 
 #### Configuring Network
 
-To interact with a custom [`ArbitrumNetwork`](./reference/dataEntities/networks), you can register it using the [`registerCustomArbitrumNetwork`](./reference/dataEntities/networks.md#registerCustomArbitrumNetwork) function.
+To interact with a custom [`ArbitrumNetwork`](./reference/dataEntities/networks), you can register it using the [`registerCustomArbitrumNetwork`](./reference/dataEntities/networks.md#registercustomarbitrumnetwork) function.
 
 ```ts
 import { registerCustomArbitrumNetwork } from '@arbitrum/sdk'

--- a/docs/2-migrate.mdx
+++ b/docs/2-migrate.mdx
@@ -25,15 +25,15 @@ Most instances of "L1" and "L2" have been replaced with "parent" and "child" res
 - The `L1Network` is no longer required to be registered before bridging.
 - Only Arbitrum networks need to be registered.
 - Arbitrum networks are defined as Arbitrum One, Arbitrum testnets, and any Orbit chain.
-- If you need a full list of Arbitrum networks, you can use the new [`getArbitrumNetworks`](./reference/dataEntities/networks#getArbitrumNetworks) function.
-- To list all of the children of a network, use the new [`getChildrenForNetwork`](./reference/dataEntities/networks#getChildrenForNetwork) function.
+- If you need a full list of Arbitrum networks, you can use the new [`getArbitrumNetworks`](./reference/dataEntities/networks#getarbitrumnetworks) function.
+- To list all of the children of a network, use the new [`getChildrenForNetwork`](./reference/dataEntities/networks#getchildrenfornetwork) function.
 
 | v3 Name               | v4 Name                                                                                            |
 | --------------------- | -------------------------------------------------------------------------------------------------- |
 | `L2Network`           | [`ArbitrumNetwork`](./reference/dataEntities/networks#arbitrumnetwork)                             |
-| `getL2Network`        | [`getArbitrumNetwork`](./reference/dataEntities/networks#getArbitrumNetwork)                       |
-| `l2Networks`          | [`getArbitrumNetworks`](./reference/dataEntities/networks#getArbitrumNetworks)                     |
-| `addCustomNetwork`    | [`registerCustomArbitrumNetwork`](./reference/dataEntities/networks#registerCustomArbitrumNetwork) |
+| `getL2Network`        | [`getArbitrumNetwork`](./reference/dataEntities/networks#getarbitrumnetwork)                       |
+| `l2Networks`          | [`getArbitrumNetworks`](./reference/dataEntities/networks#getarbitrumnetworks)                     |
+| `addCustomNetwork`    | [`registerCustomArbitrumNetwork`](./reference/dataEntities/networks#registercustomarbitrumnetwork) |
 | `Network`             | *removed*                                                                                          |
 | `L1Network`           | *removed*                                                                                          |
 | `getL1Network`        | *removed*                                                                                          |


### PR DESCRIPTION
This PR fixes a few broken links on `./docs/1-introduction.md` and `./docs/2-migrate.mdx` that impact the SDK's generated docs on arbitrum-docs.