### PR TITLE
Fix typographical errors

### DIFF
--- a/packages/sdk/src/lib/message/ChildTransaction.ts
+++ b/packages/sdk/src/lib/message/ChildTransaction.ts
@@ -191,7 +191,7 @@ export class ChildTransactionReceipt implements TransactionReceipt {
     contractTransaction.wait = async (_confirmations?: number) => {
       // we ignore the confirmations for now since child chain transactions shouldn't re-org
       // in future we should give users a more fine grained way to check the finality of
-      // an child chain transaction - check if a batch is on a parent chain, if an assertion has been made, and if
+      // a child chain transaction - check if a batch is on a parent chain, if an assertion has been made, and if
       // it has been confirmed.
       const result = await wait()
       return new ChildTransactionReceipt(result)

--- a/packages/sdk/tests/unit/childBlocksForL1Block.test.ts
+++ b/packages/sdk/tests/unit/childBlocksForL1Block.test.ts
@@ -73,7 +73,7 @@ describe('Child blocks lookup for a Parent block', () => {
     }
   }
 
-  it('successfully searches for an Child block range', async function () {
+  it('successfully searches for a Child block range', async function () {
     const childBlocks = await getBlockRangesForL1Block({
       arbitrumProvider: arbProvider,
       forL1Block: 17926532,
@@ -84,7 +84,7 @@ describe('Child blocks lookup for a Parent block', () => {
     await validateChildBlocks({ childBlocks, childBlocksCount: 2 })
   })
 
-  it('fails to search for an Child block range', async function () {
+  it('fails to search for a Child block range', async function () {
     const childBlocks = await getBlockRangesForL1Block({
       arbitrumProvider: arbProvider,
       forL1Block: 17926533,


### PR DESCRIPTION
This PR addresses typographical errors in comments and test descriptions within the following files:

#### **Files Changed**:

1. **File:** `ChildTransaction.ts`  
   - Corrected "an child chain transaction" to "a child chain transaction."

2. **File:** `childBlocksForL1Block.test.ts`  
   - Corrected "an Child block range" to "a Child block range" in multiple test descriptions.
