### PR TITLE
fixed test case in eth.test.ts

### DIFF
--- a/packages/sdk/tests/integration/eth.test.ts
+++ b/packages/sdk/tests/integration/eth.test.ts
@@ -135,7 +135,7 @@ describe('Ether', async () => {
     expect(
       initialInboxBalance.add(ethToDeposit).eq(finalInboxBalance),
       'balance failed to update after eth deposit'
-    )
+    ).to.be.true
 
     const waitResult = await rec.waitForChildTransactionReceipt(
       childSigner.provider!
@@ -208,7 +208,7 @@ describe('Ether', async () => {
     expect(
       initialInboxBalance.add(ethToDeposit).eq(finalInboxBalance),
       'balance failed to update after eth deposit'
-    )
+    ).to.be.true
 
     const parentToChildMessages = await rec.getParentToChildMessages(
       childSigner.provider!


### PR DESCRIPTION
Fixed `expect` and now it fails.

```
$ mocha --parallel tests/integration/eth.test.ts --timeout 30000 --bail


  Ether
    ✔ transfers ether on l2 (209ms)
    ✔ "EthBridger.approveGasToken" throws when eth is used as native/gas token
    1) deposits ether


  2 passing (12s)
  1 failing

  1) Ether
       deposits ether:

      balance failed to update after eth deposit
      + expected - actual

      -false
      +true
      
      at Context.<anonymous> (tests/integration/eth.test.ts:139:12)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Created the same issue before #407 but @spsjvc didn't approve it. I am one hundred percent sure that the below test case does not check anything meaningful. 

The invalid test statement is in below:
```
expect(
initialInboxBalance.add(ethToDeposit).eq(finalInboxBalance),
'balance failed to update after eth deposit'
)
```

Here's why this is meaningless:

Please log below log statements after the test case:
```
console.log('Initial balance:', initialInboxBalance.toString())
console.log('Deposit amount:', ethToDeposit.toString())
console.log(
'Expected after deposit:',
initialInboxBalance.add(ethToDeposit).toString()
)
console.log('Actual final balance:', finalInboxBalance.toString())
console.log(
'Are they equal?:',
initialInboxBalance.add(ethToDeposit).eq(finalInboxBalance)
)
```
> Initial balance: 0
> Deposit amount: 200000000000000
> Expected after deposit: 200000000000000
> Actual final balance: 0
> Are they equal?: false

As you can see even though they are not equal, the test still pass!

Btw, below statements also pass! Please check it out yourself.

```
expect(
false,
'balance failed to update after eth deposit'
)

expect(
true,
'balance failed to update after eth deposit'
)

```

The tests needs to be like below in order to actually check it:

```
expect(
initialInboxBalance.add(ethToDeposit).eq(finalInboxBalance),
'balance failed to update after eth deposit'
).to.be.true
```