### PR TITLE
ci: bump upload artifact action version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: lint-results
+          name: lint-results-${{ github.run_id }}
           path: ${{ env.TEST_PATH }}
 
       - name: Publish Test Report

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -60,7 +60,7 @@ jobs:
           yarn lint --format junit -o $TEST_PATH/sdk-lint.xml
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lint-results
           path: ${{ env.TEST_PATH }}


### PR DESCRIPTION
v3 will be completely deprecated soon so we have to bump it to v4 for actions to run

see nitro's actions failed for this reason just now:
https://github.com/OffchainLabs/nitro/actions/runs/12812191448/job/35723267943?pr=2561

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/