### PR TITLE
Fix inbox tools method getForceIncludableBlockRange

### DIFF
--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -215,7 +215,7 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          ) as Awaited<ReturnType<SequencerInbox['maxTimeVariation']>>,
+          ) as Awaited<ReturnType<SequencerInbox['maxTimeVariation']>>, //casted until sync with @arbitrum/nitro-contracts 
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),

--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -215,7 +215,7 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          )[0],
+          ) as Awaited<ReturnType<SequencerInbox['maxTimeVariation']>>,
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),


### PR DESCRIPTION
In replacement of [this PR](https://github.com/OffchainLabs/arbitrum-sdk/pull/520)

Fixes decode of SequencerInbox: maxTimeVariaton contract call.

Removed failing accesor since maxTimeVariation returns a tuple, accesing the first value was breaking on runtime.