### PR TITLE
[Test] Testnode with predeploys

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Set up the local node
         uses: OffchainLabs/actions/run-nitro-test-node@main
         with:
-          nitro-testnode-ref: release
+          nitro-testnode-ref: cb81aef3d596a22c6b1a9196f921f279fa81044f
           l3-node: ${{ matrix.orbit-test == '1' }}
           args: ${{ matrix.decimals == 16 && '--l3-fee-token --l3-fee-token-decimals 16' || matrix.decimals == 20 && '--l3-fee-token --l3-fee-token-decimals 20' || matrix.decimals == 18 && '--l3-fee-token' || '' }}
 


### PR DESCRIPTION
DO NOT MERGE

This is just a test to check that the predeployed contracts in the testnode work as intended

Note: The test `getArbitrumNetworkInformationFromRollup` seems to be failing, but looks like it's not related to the testnode