### PR TITLE
fix: replace invalid npm engine constraint with valid semver

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,7 +12,7 @@
   },
   "engines": {
     "node": ">=v11",
-    "npm": "please-use-yarn",
+    "npm": ">=7",
     "yarn": ">= 1.0.0"
   },
   "bugs": {


### PR DESCRIPTION
- `"npm": "please-use-yarn"` causes npm to silently install v2.0.0 instead of v4.x
- npm's resolver skips versions with unsatisfiable engine constraints
- Changed to `"npm": ">=7"` so npm users get the correct version