### PR TITLE
fix: convert L1 block numbers to L2 ranges for Orbit chains

### DIFF
--- a/packages/sdk/src/lib/message/ChildToParentMessageNitro.ts
+++ b/packages/sdk/src/lib/message/ChildToParentMessageNitro.ts
@@ -473,10 +473,11 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
           )
           const eventFetcher = new EventFetcher(rollup.provider)
 
-          const { fromBlock: queryFromBlock } = await this.getChildChainBlockRange(
-            latestConfirmedAssertion.createdAtBlock,
-            childProvider
-          )
+          const { fromBlock: queryFromBlock } =
+            await this.getChildChainBlockRange(
+              latestConfirmedAssertion.createdAtBlock,
+              childProvider
+            )
 
           const assertionCreatedEvents = await eventFetcher.getEvents(
             BoldRollupUserLogic__factory,


### PR DESCRIPTION
## Summary
- Extract `getL2BlockRange()` helper that converts L1 block numbers to L2 block ranges when the parent chain is Arbitrum (Orbit/L3)
- Apply the conversion in `getSendProps()` before querying `eth_getLogs`, fixing the `withdraws erc20` L3 integration test failure
- Refactor `getBlockFromAssertionId()` to use the same helper, deduplicating the conversion logic

## Context
After Nitro v3.9.0, upstream geth changed `eth_getLogs` to validate `fromBlock <= chain head` when `toBlock: "latest"`. On Orbit chains, `getSendProps()` passed an L1 block number (from `rollup.getAssertion().createdAtBlock`) as `fromBlock` when querying events on an L2 parent chain. The L1 block number could exceed the L2's actual block count, triggering the new validation error.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test:unit` passes (55 passing)
- [x] `yarn lint` passes
- [x] `ORBIT_TEST=1 yarn test:integration` passes (50 passing, 0 failing)