### PR TITLE
feat: configurable max block range for EventFetcher chunking

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -79,10 +79,7 @@ export {
   mapL2NetworkTokenBridgeToTokenBridge,
 } from './lib/dataEntities/networks'
 export { InboxTools } from './lib/inbox/inbox'
-export {
-  EventFetcher,
-  DEFAULT_MAX_BLOCK_RANGE,
-} from './lib/utils/eventFetcher'
+export { EventFetcher, DEFAULT_MAX_BLOCK_RANGE } from './lib/utils/eventFetcher'
 export { ArbitrumProvider } from './lib/utils/arbProvider'
 export * as constants from './lib/dataEntities/constants'
 export {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -79,7 +79,10 @@ export {
   mapL2NetworkTokenBridgeToTokenBridge,
 } from './lib/dataEntities/networks'
 export { InboxTools } from './lib/inbox/inbox'
-export { EventFetcher } from './lib/utils/eventFetcher'
+export {
+  EventFetcher,
+  DEFAULT_MAX_BLOCK_RANGE,
+} from './lib/utils/eventFetcher'
 export { ArbitrumProvider } from './lib/utils/arbProvider'
 export * as constants from './lib/dataEntities/constants'
 export {

--- a/packages/sdk/src/lib/message/ChildToParentMessageNitro.ts
+++ b/packages/sdk/src/lib/message/ChildToParentMessageNitro.ts
@@ -194,11 +194,31 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
   protected outboxAddress?: string
   protected l1BatchNumber?: number
 
+  /**
+   * Optional maximum block range for parent chain log queries.
+   * When set, EventFetcher will automatically chunk queries that
+   * exceed this range. Useful for RPC providers with block range
+   * limits (e.g. free-tier nodes capped at 10,000 blocks).
+   *
+   * Set via {@link setMaxBlockRange} after construction.
+   */
+  protected parentChainMaxBlockRange?: number
+
   constructor(
     protected readonly parentProvider: Provider,
     event: EventArgs<ChildToParentTxEvent>
   ) {
     super(event)
+  }
+
+  /**
+   * Set the maximum block range for parent chain log queries.
+   * When set, large block range queries are automatically split into
+   * smaller chunks to work with RPC providers that have range limits.
+   * @param maxBlockRange Maximum number of blocks per getLogs query
+   */
+  public setMaxBlockRange(maxBlockRange: number): void {
+    this.parentChainMaxBlockRange = maxBlockRange
   }
 
   public async getOutboxProof(childProvider: Provider) {
@@ -388,7 +408,10 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
       await this.getChildChainBlockRange(createdAtBlock, childProvider)
 
     // now get the block hash and sendroot for that node
-    const eventFetcher = new EventFetcher(rollup.provider)
+    const eventFetcher = new EventFetcher(
+      rollup.provider,
+      this.parentChainMaxBlockRange
+    )
 
     const logs:
       | FetchedEvent<NodeCreatedEvent>[]
@@ -471,7 +494,10 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
           const latestConfirmedAssertion = await rollup.getAssertion(
             latestConfirmed
           )
-          const eventFetcher = new EventFetcher(rollup.provider)
+          const eventFetcher = new EventFetcher(
+            rollup.provider,
+            this.parentChainMaxBlockRange
+          )
 
           const { fromBlock: queryFromBlock } =
             await this.getChildChainBlockRange(
@@ -640,7 +666,10 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
       throw new ArbSdkError('ChildToParentMsg expected to be unconfirmed')
 
     const latestBlock = await this.parentProvider.getBlockNumber()
-    const eventFetcher = new EventFetcher(this.parentProvider)
+    const eventFetcher = new EventFetcher(
+      this.parentProvider,
+      this.parentChainMaxBlockRange
+    )
     let logs:
       | FetchedEvent<NodeCreatedEvent>[]
       | FetchedEvent<AssertionCreatedEvent>[]

--- a/packages/sdk/src/lib/message/ChildToParentMessageNitro.ts
+++ b/packages/sdk/src/lib/message/ChildToParentMessageNitro.ts
@@ -194,31 +194,11 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
   protected outboxAddress?: string
   protected l1BatchNumber?: number
 
-  /**
-   * Optional maximum block range for parent chain log queries.
-   * When set, EventFetcher will automatically chunk queries that
-   * exceed this range. Useful for RPC providers with block range
-   * limits (e.g. free-tier nodes capped at 10,000 blocks).
-   *
-   * Set via {@link setMaxBlockRange} after construction.
-   */
-  protected parentChainMaxBlockRange?: number
-
   constructor(
     protected readonly parentProvider: Provider,
     event: EventArgs<ChildToParentTxEvent>
   ) {
     super(event)
-  }
-
-  /**
-   * Set the maximum block range for parent chain log queries.
-   * When set, large block range queries are automatically split into
-   * smaller chunks to work with RPC providers that have range limits.
-   * @param maxBlockRange Maximum number of blocks per getLogs query
-   */
-  public setMaxBlockRange(maxBlockRange: number): void {
-    this.parentChainMaxBlockRange = maxBlockRange
   }
 
   public async getOutboxProof(childProvider: Provider) {
@@ -408,10 +388,7 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
       await this.getChildChainBlockRange(createdAtBlock, childProvider)
 
     // now get the block hash and sendroot for that node
-    const eventFetcher = new EventFetcher(
-      rollup.provider,
-      this.parentChainMaxBlockRange
-    )
+    const eventFetcher = new EventFetcher(rollup.provider)
 
     const logs:
       | FetchedEvent<NodeCreatedEvent>[]
@@ -494,10 +471,7 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
           const latestConfirmedAssertion = await rollup.getAssertion(
             latestConfirmed
           )
-          const eventFetcher = new EventFetcher(
-            rollup.provider,
-            this.parentChainMaxBlockRange
-          )
+          const eventFetcher = new EventFetcher(rollup.provider)
 
           const { fromBlock: queryFromBlock } =
             await this.getChildChainBlockRange(
@@ -666,10 +640,7 @@ export class ChildToParentMessageReaderNitro extends ChildToParentMessageNitro {
       throw new ArbSdkError('ChildToParentMsg expected to be unconfirmed')
 
     const latestBlock = await this.parentProvider.getBlockNumber()
-    const eventFetcher = new EventFetcher(
-      this.parentProvider,
-      this.parentChainMaxBlockRange
-    )
+    const eventFetcher = new EventFetcher(this.parentProvider)
     let logs:
       | FetchedEvent<NodeCreatedEvent>[]
       | FetchedEvent<AssertionCreatedEvent>[]

--- a/packages/sdk/src/lib/utils/eventFetcher.ts
+++ b/packages/sdk/src/lib/utils/eventFetcher.ts
@@ -42,10 +42,21 @@ export type FetchedEvent<TEvent extends Event> = {
 type TEventOf<T> = T extends TypedEventFilter<infer TEvent> ? TEvent : never
 
 /**
- * Fetches and parses blockchain logs
+ * Fetches and parses blockchain logs, with optional chunked querying
+ * for RPC providers that limit block ranges.
  */
 export class EventFetcher {
-  public constructor(public readonly provider: Provider) {}
+  /**
+   * @param provider The provider to fetch logs from
+   * @param maxBlockRange Optional maximum block range per query. When set,
+   *   queries spanning more than this many blocks are automatically split
+   *   into sequential chunks. Useful for RPC providers with block range limits
+   *   (e.g. free-tier nodes that cap at 10,000 blocks).
+   */
+  public constructor(
+    public readonly provider: Provider,
+    public readonly maxBlockRange?: number
+  ) {}
 
   /**
    * Fetch logs and parse logs
@@ -77,7 +88,7 @@ export class EventFetcher {
       fromBlock: filter.fromBlock,
       toBlock: filter.toBlock,
     }
-    const logs = await this.provider.getLogs(fullFilter)
+    const logs = await this.getLogsWithChunking(fullFilter)
     return logs
       .filter(l => l.removed === false)
       .map(l => {
@@ -96,5 +107,55 @@ export class EventFetcher {
           data: l.data,
         }
       }) as FetchedEvent<TEventOf<TEventFilter>>[]
+  }
+
+  private async getLogsWithChunking(
+    filter: Filter
+  ): Promise<import('@ethersproject/abstract-provider').Log[]> {
+    if (!this.maxBlockRange) {
+      return this.provider.getLogs(filter)
+    }
+
+    const fromBlock =
+      typeof filter.fromBlock === 'number'
+        ? filter.fromBlock
+        : typeof filter.fromBlock === 'string' && filter.fromBlock !== 'latest'
+          ? parseInt(filter.fromBlock, 16)
+          : null
+
+    let toBlock: number | null = null
+    if (typeof filter.toBlock === 'number') {
+      toBlock = filter.toBlock
+    } else if (filter.toBlock === 'latest' || filter.toBlock === undefined) {
+      toBlock = await this.provider.getBlockNumber()
+    } else if (typeof filter.toBlock === 'string') {
+      toBlock = parseInt(filter.toBlock, 16)
+    }
+
+    if (fromBlock === null || toBlock === null) {
+      return this.provider.getLogs(filter)
+    }
+
+    const range = toBlock - fromBlock
+    if (range <= this.maxBlockRange) {
+      return this.provider.getLogs(filter)
+    }
+
+    const allLogs: import('@ethersproject/abstract-provider').Log[] = []
+    for (
+      let start = fromBlock;
+      start <= toBlock;
+      start += this.maxBlockRange + 1
+    ) {
+      const end = Math.min(start + this.maxBlockRange, toBlock)
+      const chunkLogs = await this.provider.getLogs({
+        ...filter,
+        fromBlock: start,
+        toBlock: end,
+      })
+      allLogs.push(...chunkLogs)
+    }
+
+    return allLogs
   }
 }

--- a/packages/sdk/src/lib/utils/eventFetcher.ts
+++ b/packages/sdk/src/lib/utils/eventFetcher.ts
@@ -16,11 +16,14 @@
 /* eslint-env node */
 'use strict'
 
-import { Provider, BlockTag, Filter } from '@ethersproject/abstract-provider'
+import { Provider, BlockTag, Filter, Log } from '@ethersproject/abstract-provider'
 import { Contract, Event } from '@ethersproject/contracts'
 import { constants } from 'ethers'
 import { TypedEvent, TypedEventFilter } from '../abi/common'
 import { EventArgs, TypeChainContractFactory } from '../dataEntities/event'
+
+const DEFAULT_MAX_BLOCK_RANGE = 10_000
+const MIN_CHUNK_SIZE = 500
 
 export type FetchedEvent<TEvent extends Event> = {
   event: EventArgs<TEvent>
@@ -42,21 +45,10 @@ export type FetchedEvent<TEvent extends Event> = {
 type TEventOf<T> = T extends TypedEventFilter<infer TEvent> ? TEvent : never
 
 /**
- * Fetches and parses blockchain logs, with optional chunked querying
- * for RPC providers that limit block ranges.
+ * Fetches and parses blockchain logs
  */
 export class EventFetcher {
-  /**
-   * @param provider The provider to fetch logs from
-   * @param maxBlockRange Optional maximum block range per query. When set,
-   *   queries spanning more than this many blocks are automatically split
-   *   into sequential chunks. Useful for RPC providers with block range limits
-   *   (e.g. free-tier nodes that cap at 10,000 blocks).
-   */
-  public constructor(
-    public readonly provider: Provider,
-    public readonly maxBlockRange?: number
-  ) {}
+  public constructor(public readonly provider: Provider) {}
 
   /**
    * Fetch logs and parse logs
@@ -109,51 +101,87 @@ export class EventFetcher {
       }) as FetchedEvent<TEventOf<TEventFilter>>[]
   }
 
+  private async resolveBlockTag(
+    blockTag: BlockTag | undefined
+  ): Promise<number | null> {
+    if (typeof blockTag === 'number') {
+      if (blockTag >= 0) return blockTag
+
+      const latestBlock = await this.provider.getBlockNumber()
+      return Math.max(latestBlock + blockTag, 0)
+    }
+    if (blockTag === 'earliest') return 0
+    if (typeof blockTag === 'string' && blockTag.startsWith('0x')) {
+      const parsed = parseInt(blockTag, 16)
+      return isNaN(parsed) ? null : parsed
+    }
+    // 'latest', 'pending', 'safe', 'finalized', undefined
+    const block = await this.provider.getBlock(blockTag ?? 'latest')
+    return block?.number ?? null
+  }
+
   private async getLogsWithChunking(
     filter: Filter
-  ): Promise<import('@ethersproject/abstract-provider').Log[]> {
-    if (!this.maxBlockRange) {
-      return this.provider.getLogs(filter)
+  ): Promise<Log[]> {
+    try {
+      return await this.provider.getLogs(filter)
+    } catch (error) {
+      const fromBlock = await this.resolveBlockTag(filter.fromBlock)
+      const toBlock = await this.resolveBlockTag(filter.toBlock)
+
+      if (fromBlock === null || toBlock === null) {
+        throw error
+      }
+
+      const initialChunkSize = Math.min(
+        DEFAULT_MAX_BLOCK_RANGE,
+        toBlock - fromBlock + 1
+      )
+
+      if (initialChunkSize <= 0) {
+        throw error
+      }
+
+      return this.fetchLogsInRange(filter, fromBlock, toBlock, initialChunkSize)
     }
+  }
 
-    const fromBlock =
-      typeof filter.fromBlock === 'number'
-        ? filter.fromBlock
-        : typeof filter.fromBlock === 'string' && filter.fromBlock !== 'latest'
-          ? parseInt(filter.fromBlock, 16)
-          : null
+  private async fetchLogsInRange(
+    filter: Filter,
+    fromBlock: number,
+    toBlock: number,
+    chunkSize: number
+  ): Promise<Log[]> {
+    const allLogs: Log[] = []
+    let start = fromBlock
 
-    let toBlock: number | null = null
-    if (typeof filter.toBlock === 'number') {
-      toBlock = filter.toBlock
-    } else if (filter.toBlock === 'latest' || filter.toBlock === undefined) {
-      toBlock = await this.provider.getBlockNumber()
-    } else if (typeof filter.toBlock === 'string') {
-      toBlock = parseInt(filter.toBlock, 16)
-    }
+    while (start <= toBlock) {
+      if (start > fromBlock) {
+        await new Promise(r => setTimeout(r, 100))
+      }
 
-    if (fromBlock === null || toBlock === null) {
-      return this.provider.getLogs(filter)
-    }
-
-    const range = toBlock - fromBlock
-    if (range <= this.maxBlockRange) {
-      return this.provider.getLogs(filter)
-    }
-
-    const allLogs: import('@ethersproject/abstract-provider').Log[] = []
-    for (
-      let start = fromBlock;
-      start <= toBlock;
-      start += this.maxBlockRange + 1
-    ) {
-      const end = Math.min(start + this.maxBlockRange, toBlock)
-      const chunkLogs = await this.provider.getLogs({
-        ...filter,
-        fromBlock: start,
-        toBlock: end,
-      })
-      allLogs.push(...chunkLogs)
+      const end = Math.min(start + chunkSize - 1, toBlock)
+      try {
+        const chunkLogs = await this.provider.getLogs({
+          ...filter,
+          fromBlock: start,
+          toBlock: end,
+        })
+        allLogs.push(...chunkLogs)
+      } catch (error) {
+        if (chunkSize > MIN_CHUNK_SIZE) {
+          const retryLogs = await this.fetchLogsInRange(
+            filter,
+            start,
+            end,
+            Math.floor(chunkSize / 2)
+          )
+          allLogs.push(...retryLogs)
+        } else {
+          throw error
+        }
+      }
+      start = end + 1
     }
 
     return allLogs

--- a/packages/sdk/src/lib/utils/eventFetcher.ts
+++ b/packages/sdk/src/lib/utils/eventFetcher.ts
@@ -27,7 +27,7 @@ import { constants } from 'ethers'
 import { TypedEvent, TypedEventFilter } from '../abi/common'
 import { EventArgs, TypeChainContractFactory } from '../dataEntities/event'
 
-const DEFAULT_MAX_BLOCK_RANGE = 10_000
+export const DEFAULT_MAX_BLOCK_RANGE = 10_000
 const MIN_CHUNK_SIZE = 500
 
 export type FetchedEvent<TEvent extends Event> = {
@@ -53,6 +53,16 @@ type TEventOf<T> = T extends TypedEventFilter<infer TEvent> ? TEvent : never
  * Fetches and parses blockchain logs
  */
 export class EventFetcher {
+  private static maxBlockRange: number = DEFAULT_MAX_BLOCK_RANGE
+
+  /**
+   * Set the maximum block range used by all EventFetcher instances
+   * when chunking log queries after an initial failure.
+   */
+  public static setMaxBlockRange(maxBlockRange: number): void {
+    EventFetcher.maxBlockRange = maxBlockRange
+  }
+
   public constructor(public readonly provider: Provider) {}
 
   /**
@@ -137,7 +147,7 @@ export class EventFetcher {
       }
 
       const initialChunkSize = Math.min(
-        DEFAULT_MAX_BLOCK_RANGE,
+        EventFetcher.maxBlockRange,
         toBlock - fromBlock + 1
       )
 

--- a/packages/sdk/src/lib/utils/eventFetcher.ts
+++ b/packages/sdk/src/lib/utils/eventFetcher.ts
@@ -16,7 +16,12 @@
 /* eslint-env node */
 'use strict'
 
-import { Provider, BlockTag, Filter, Log } from '@ethersproject/abstract-provider'
+import {
+  Provider,
+  BlockTag,
+  Filter,
+  Log,
+} from '@ethersproject/abstract-provider'
 import { Contract, Event } from '@ethersproject/contracts'
 import { constants } from 'ethers'
 import { TypedEvent, TypedEventFilter } from '../abi/common'
@@ -120,9 +125,7 @@ export class EventFetcher {
     return block?.number ?? null
   }
 
-  private async getLogsWithChunking(
-    filter: Filter
-  ): Promise<Log[]> {
+  private async getLogsWithChunking(filter: Filter): Promise<Log[]> {
     try {
       return await this.provider.getLogs(filter)
     } catch (error) {

--- a/packages/sdk/tests/unit/eventFetcher.test.ts
+++ b/packages/sdk/tests/unit/eventFetcher.test.ts
@@ -1,0 +1,311 @@
+import { Logger, LogLevel } from '@ethersproject/logger'
+Logger.setLogLevel(LogLevel.ERROR)
+
+import { Log } from '@ethersproject/abstract-provider'
+import { expect } from 'chai'
+import { providers } from 'ethers'
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito'
+import { EventFetcher } from '../../src/lib/utils/eventFetcher'
+
+const TEST_TOPIC =
+  '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+const TEST_ADDRESS = '0x0000000000000000000000000000000000000001'
+
+function makeFakeLog(blockNumber: number, data = '0x'): Log {
+  return {
+    blockNumber,
+    blockHash: `0x${'00'.repeat(31)}${blockNumber
+      .toString(16)
+      .padStart(2, '0')}`,
+    transactionIndex: 0,
+    removed: false,
+    address: TEST_ADDRESS,
+    data,
+    topics: [TEST_TOPIC],
+    transactionHash: `0x${'aa'.repeat(32)}`,
+    logIndex: 0,
+  }
+}
+
+function createMockContractFactory() {
+  const contractFactory = {
+    connect: (_address: string, _provider: unknown) => ({
+      interface: {
+        parseLog: (log: Log) => ({
+          args: { data: log.data },
+          topic: log.topics[0],
+          name: 'TestEvent',
+        }),
+      },
+      filters: {},
+    }),
+    createInterface: () => ({}),
+  }
+
+  const topicGenerator = (_contract: unknown) => ({
+    topics: [TEST_TOPIC],
+  })
+
+  return { contractFactory, topicGenerator }
+}
+
+describe('EventFetcher chunking', () => {
+  const { contractFactory, topicGenerator } = createMockContractFactory()
+
+  function createProvider(latestBlockNumber = 10000) {
+    const providerMock = mock(providers.JsonRpcProvider)
+    when(providerMock._isProvider).thenReturn(true)
+    when(providerMock.getLogs(anything())).thenResolve([])
+    when(providerMock.getBlockNumber()).thenResolve(latestBlockNumber)
+    when(providerMock.getBlock(anything())).thenResolve({
+      number: latestBlockNumber,
+    } as any)
+    return { providerMock, provider: instance(providerMock) }
+  }
+
+  it('falls back to chunking with the default maxBlockRange after an initial failure', async () => {
+    const { providerMock, provider } = createProvider()
+    const fetcher = new EventFetcher(provider)
+
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 0,
+          toBlock: 10000,
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+
+    await fetcher.getEvents(contractFactory as any, topicGenerator as any, {
+      fromBlock: 0,
+      toBlock: 10000,
+    })
+
+    verify(providerMock.getLogs(anything())).thrice()
+    verify(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 0,
+          toBlock: 9999,
+        })
+      )
+    ).once()
+    verify(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 10000,
+          toBlock: 10000,
+        })
+      )
+    ).once()
+  })
+
+  it('resolves negative fromBlock values before stepping off', async () => {
+    const { providerMock, provider } = createProvider(25000)
+    const fetcher = new EventFetcher(provider)
+
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: -20000,
+          toBlock: 'latest',
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+
+    await fetcher.getEvents(contractFactory as any, topicGenerator as any, {
+      fromBlock: -20000,
+      toBlock: 'latest',
+    })
+
+    verify(providerMock.getBlockNumber()).once()
+    verify(providerMock.getBlock(anything())).once()
+    verify(providerMock.getLogs(anything())).times(4)
+    verify(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 5000,
+          toBlock: 14999,
+        })
+      )
+    ).once()
+    verify(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 15000,
+          toBlock: 24999,
+        })
+      )
+    ).once()
+    verify(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 25000,
+          toBlock: 25000,
+        })
+      )
+    ).once()
+  })
+
+  it('naively retries smaller chunks and preserves log order', async () => {
+    const { providerMock, provider } = createProvider()
+    const log0 = makeFakeLog(500, '0x01')
+    const log1 = makeFakeLog(1200, '0x02')
+    const log2 = makeFakeLog(1800, '0x03')
+    const log3 = makeFakeLog(2300, '0x04')
+
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 0,
+          toBlock: 25000,
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 0,
+          toBlock: 9999,
+        })
+      )
+    ).thenResolve([log0])
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 10000,
+          toBlock: 19999,
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 10000,
+          toBlock: 14999,
+        })
+      )
+    ).thenResolve([log1])
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 15000,
+          toBlock: 19999,
+        })
+      )
+    ).thenResolve([log2])
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 20000,
+          toBlock: 25000,
+        })
+      )
+    ).thenResolve([log3])
+
+    const fetcher = new EventFetcher(provider)
+    const events = await fetcher.getEvents(
+      contractFactory as any,
+      topicGenerator as any,
+      {
+        fromBlock: 0,
+        toBlock: 25000,
+      }
+    )
+
+    expect(events.map(event => event.blockNumber)).to.deep.equal([
+      500, 1200, 1800, 2300,
+    ])
+    expect(events.map(event => event.data)).to.deep.equal([
+      '0x01',
+      '0x02',
+      '0x03',
+      '0x04',
+    ])
+  })
+
+  it('rethrows once naive retries reach MIN_CHUNK_SIZE', async () => {
+    const { providerMock, provider } = createProvider()
+
+    when(providerMock.getLogs(anything())).thenReject(new Error('rate limited'))
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 0,
+          toBlock: 25000,
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 0,
+          toBlock: 9999,
+        })
+      )
+    ).thenResolve([makeFakeLog(500)])
+
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 10000,
+          toBlock: 19999,
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+    when(
+      providerMock.getLogs(
+        deepEqual({
+          topics: [TEST_TOPIC],
+          address: undefined,
+          fromBlock: 10000,
+          toBlock: 14999,
+        })
+      )
+    ).thenReject(new Error('rate limited'))
+
+    const fetcher = new EventFetcher(provider)
+
+    try {
+      await fetcher.getEvents(contractFactory as any, topicGenerator as any, {
+        fromBlock: 0,
+        toBlock: 25000,
+      })
+      expect.fail('Should have thrown')
+    } catch (error: any) {
+      expect(error.message).to.equal('rate limited')
+    }
+  })
+})

--- a/packages/sdk/tests/unit/eventFetcher.test.ts
+++ b/packages/sdk/tests/unit/eventFetcher.test.ts
@@ -250,6 +250,65 @@ describe('EventFetcher chunking', () => {
     ])
   })
 
+  it('uses custom maxBlockRange set via static setter', async () => {
+    EventFetcher.setMaxBlockRange(2000)
+    try {
+      const { providerMock, provider } = createProvider(5000)
+      const fetcher = new EventFetcher(provider)
+
+      when(
+        providerMock.getLogs(
+          deepEqual({
+            topics: [TEST_TOPIC],
+            address: undefined,
+            fromBlock: 0,
+            toBlock: 5000,
+          })
+        )
+      ).thenReject(new Error('rate limited'))
+
+      await fetcher.getEvents(contractFactory as any, topicGenerator as any, {
+        fromBlock: 0,
+        toBlock: 5000,
+      })
+
+      // With maxBlockRange=2000, chunks should be [0-1999], [2000-3999], [4000-5000]
+      verify(providerMock.getLogs(anything())).times(4) // 1 initial + 3 chunks
+      verify(
+        providerMock.getLogs(
+          deepEqual({
+            topics: [TEST_TOPIC],
+            address: undefined,
+            fromBlock: 0,
+            toBlock: 1999,
+          })
+        )
+      ).once()
+      verify(
+        providerMock.getLogs(
+          deepEqual({
+            topics: [TEST_TOPIC],
+            address: undefined,
+            fromBlock: 2000,
+            toBlock: 3999,
+          })
+        )
+      ).once()
+      verify(
+        providerMock.getLogs(
+          deepEqual({
+            topics: [TEST_TOPIC],
+            address: undefined,
+            fromBlock: 4000,
+            toBlock: 5000,
+          })
+        )
+      ).once()
+    } finally {
+      EventFetcher.setMaxBlockRange(10_000)
+    }
+  })
+
   it('rethrows once naive retries reach MIN_CHUNK_SIZE', async () => {
     const { providerMock, provider } = createProvider()
 


### PR DESCRIPTION
## Summary
- EventFetcher now auto-chunks log queries on RPC failure with exponential backoff (retry with halved chunk size down to 500 blocks)
- `EventFetcher.setMaxBlockRange(n)` lets callers configure the initial chunk size globally (defaults to 10,000)
- `DEFAULT_MAX_BLOCK_RANGE` exported for reference

## Usage
```ts
import { EventFetcher } from '@arbitrum/sdk'

// Set once at app startup — applies to all EventFetcher instances
EventFetcher.setMaxBlockRange(5000)
```

## Test plan
- [x] Existing chunking tests pass (fallback, negative blocks, retry with smaller chunks, min chunk error)
- [x] New test: `setMaxBlockRange` produces correct chunk boundaries (2000-block chunks)
- [x] Static setter resets cleanly between tests