### PR TITLE
Fix force inclusion

### DIFF
--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -19,7 +19,7 @@
 import { Signer } from '@ethersproject/abstract-signer'
 import { Block, Provider } from '@ethersproject/abstract-provider'
 import { BigNumber, ContractTransaction, ethers, Overrides } from 'ethers'
-import { TransactionRequest, JsonRpcProvider } from '@ethersproject/providers'
+import { TransactionRequest } from '@ethersproject/providers'
 
 import { Bridge } from '../abi/Bridge'
 import { Bridge__factory } from '../abi/factories/Bridge__factory'
@@ -37,11 +37,11 @@ import { NodeInterface__factory } from '../abi/factories/NodeInterface__factory'
 import { NODE_INTERFACE_ADDRESS } from '../dataEntities/constants'
 import { InboxMessageKind } from '../dataEntities/message'
 import {
-  getBlockRangesForL1Block,
+  getFirstArbBlockForL1Block,
+  getL1BlockNumberOfArbBlock,
   isArbitrumChain,
   isDefined,
 } from '../utils/lib'
-import { ArbitrumProvider } from '../utils/arbProvider'
 
 type ForceInclusionParams = FetchedEvent<MessageDeliveredEvent> & {
   delayedAcc: string
@@ -90,39 +90,9 @@ export class InboxTools {
   ): Promise<Block> {
     const isParentChainArbitrum = await isArbitrumChain(this.parentProvider)
 
-    // For Arbitrum parent chains, blockNumber is an L1 block number.
-    // We map it to an L2 block number for getBlock, but recurse with the
-    // original L1 block number to avoid passing L2 numbers into l2BlockRangeForL1.
-    let l2BlockNumber = blockNumber
-    if (isParentChainArbitrum) {
-      const nodeInterface = NodeInterface__factory.connect(
-        NODE_INTERFACE_ADDRESS,
-        this.parentProvider
-      )
-
-      try {
-        l2BlockNumber = (
-          await nodeInterface.l2BlockRangeForL1(blockNumber - 1)
-        ).firstBlock.toNumber()
-      } catch (e) {
-        // l2BlockRangeForL1 reverts if no L2 block exist with the given L1 block number,
-        // since l1 block is updated in batch sometimes block can be skipped even when there are activities
-        // alternatively we use binary search to get the nearest block
-        const _blockNum = (
-          await getBlockRangesForL1Block({
-            arbitrumProvider: this.parentProvider as JsonRpcProvider,
-            forL1Block: blockNumber - 1,
-            allowGreater: true,
-          })
-        )[0]
-
-        if (!_blockNum) {
-          throw e
-        }
-
-        l2BlockNumber = _blockNum
-      }
-    }
+    const l2BlockNumber = isParentChainArbitrum
+      ? await getFirstArbBlockForL1Block(this.parentProvider, blockNumber - 1)
+      : blockNumber
 
     const block = await this.parentProvider.getBlock(l2BlockNumber)
     const diff = block.timestamp - blockTimestamp
@@ -198,11 +168,10 @@ export class InboxTools {
     const isParentChainArbitrum = await isArbitrumChain(this.parentProvider)
 
     if (isParentChainArbitrum) {
-      const arbProvider = new ArbitrumProvider(
-        this.parentProvider as JsonRpcProvider
+      currentL1BlockNumber = await getL1BlockNumberOfArbBlock(
+        this.parentProvider,
+        'latest'
       )
-      const currentArbBlock = await arbProvider.getBlock('latest')
-      currentL1BlockNumber = currentArbBlock.l1BlockNumber
     }
 
     const multicall = await MultiCaller.fromProvider(this.parentProvider)
@@ -384,17 +353,12 @@ export class InboxTools {
     if (!eventInfo) return null
     const block = await this.parentProvider.getBlock(eventInfo.blockHash)
 
-    // When the parent chain is an Arbitrum chain, block.number in Solidity
-    // returns the L1 block number (not the Arb block number). We need to pass
-    // the L1 block number that corresponds to the event's Arb block.
     let l1BlockNumber: number = eventInfo.blockNumber
-    const isParentChainArbitrum = await isArbitrumChain(this.parentProvider)
-    if (isParentChainArbitrum) {
-      const arbProvider = new ArbitrumProvider(
-        this.parentProvider as JsonRpcProvider
+    if (await isArbitrumChain(this.parentProvider)) {
+      l1BlockNumber = await getL1BlockNumberOfArbBlock(
+        this.parentProvider,
+        eventInfo.blockNumber
       )
-      const arbBlock = await arbProvider.getBlock(eventInfo.blockNumber)
-      l1BlockNumber = arbBlock.l1BlockNumber
     }
 
     return await sequencerInbox.functions.forceInclusion(

--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -219,7 +219,9 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          ),
+          ) as unknown as Awaited<
+            ReturnType<SequencerInbox['maxTimeVariation']>
+          >,
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),

--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -90,6 +90,10 @@ export class InboxTools {
   ): Promise<Block> {
     const isParentChainArbitrum = await isArbitrumChain(this.parentProvider)
 
+    // For Arbitrum parent chains, blockNumber is an L1 block number.
+    // We map it to an L2 block number for getBlock, but recurse with the
+    // original L1 block number to avoid passing L2 numbers into l2BlockRangeForL1.
+    let l2BlockNumber = blockNumber
     if (isParentChainArbitrum) {
       const nodeInterface = NodeInterface__factory.connect(
         NODE_INTERFACE_ADDRESS,
@@ -97,7 +101,7 @@ export class InboxTools {
       )
 
       try {
-        blockNumber = (
+        l2BlockNumber = (
           await nodeInterface.l2BlockRangeForL1(blockNumber - 1)
         ).firstBlock.toNumber()
       } catch (e) {
@@ -116,11 +120,11 @@ export class InboxTools {
           throw e
         }
 
-        blockNumber = _blockNum
+        l2BlockNumber = _blockNum
       }
     }
 
-    const block = await this.parentProvider.getBlock(blockNumber)
+    const block = await this.parentProvider.getBlock(l2BlockNumber)
     const diff = block.timestamp - blockTimestamp
     if (diff < 0) return block
 

--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -215,7 +215,7 @@ export class InboxTools {
           sequencerInbox.interface.decodeFunctionResult(
             'maxTimeVariation',
             returnData
-          )[0],
+          ),
       },
       multicall.getBlockNumberInput(),
       multicall.getCurrentBlockTimestampInput(),
@@ -378,10 +378,23 @@ export class InboxTools {
     if (!eventInfo) return null
     const block = await this.parentProvider.getBlock(eventInfo.blockHash)
 
+    // When the parent chain is an Arbitrum chain, block.number in Solidity
+    // returns the L1 block number (not the Arb block number). We need to pass
+    // the L1 block number that corresponds to the event's Arb block.
+    let l1BlockNumber: number = eventInfo.blockNumber
+    const isParentChainArbitrum = await isArbitrumChain(this.parentProvider)
+    if (isParentChainArbitrum) {
+      const arbProvider = new ArbitrumProvider(
+        this.parentProvider as JsonRpcProvider
+      )
+      const arbBlock = await arbProvider.getBlock(eventInfo.blockNumber)
+      l1BlockNumber = arbBlock.l1BlockNumber
+    }
+
     return await sequencerInbox.functions.forceInclusion(
       eventInfo.event.messageIndex.add(1),
       eventInfo.event.kind,
-      [eventInfo.blockNumber, block.timestamp],
+      [l1BlockNumber, block.timestamp],
       eventInfo.event.baseFeeL1,
       eventInfo.event.sender,
       eventInfo.event.messageDataHash,

--- a/packages/sdk/src/lib/inbox/inbox.ts
+++ b/packages/sdk/src/lib/inbox/inbox.ts
@@ -90,11 +90,11 @@ export class InboxTools {
   ): Promise<Block> {
     const isParentChainArbitrum = await isArbitrumChain(this.parentProvider)
 
-    const l2BlockNumber = isParentChainArbitrum
+    const parentChainBlockNumber = isParentChainArbitrum
       ? await getFirstArbBlockForL1Block(this.parentProvider, blockNumber - 1)
       : blockNumber
 
-    const block = await this.parentProvider.getBlock(l2BlockNumber)
+    const block = await this.parentProvider.getBlock(parentChainBlockNumber)
     const diff = block.timestamp - blockTimestamp
     if (diff < 0) return block
 

--- a/packages/sdk/src/lib/utils/lib.ts
+++ b/packages/sdk/src/lib/utils/lib.ts
@@ -4,7 +4,11 @@ import { TransactionReceipt, JsonRpcProvider } from '@ethersproject/providers'
 import { ArbSdkError } from '../dataEntities/errors'
 import { ArbitrumProvider } from './arbProvider'
 import { ArbSys__factory } from '../abi/factories/ArbSys__factory'
-import { ARB_SYS_ADDRESS } from '../dataEntities/constants'
+import {
+  ARB_SYS_ADDRESS,
+  NODE_INTERFACE_ADDRESS,
+} from '../dataEntities/constants'
+import { NodeInterface__factory } from '../abi/factories/NodeInterface__factory'
 import { ArbitrumNetwork, getNitroGenesisBlock } from '../dataEntities/networks'
 import { ERC20__factory } from '../abi/factories/ERC20__factory'
 
@@ -66,6 +70,47 @@ export const isArbitrumChain = async (provider: Provider): Promise<boolean> => {
     return false
   }
   return true
+}
+
+/**
+ * Get the L1 block number for a given block on an Arbitrum chain.
+ */
+export async function getL1BlockNumberOfArbBlock(
+  provider: Provider,
+  blockNumber: number | 'latest'
+): Promise<number> {
+  const arbProvider = new ArbitrumProvider(provider as JsonRpcProvider)
+  const arbBlock = await arbProvider.getBlock(blockNumber)
+  return arbBlock.l1BlockNumber
+}
+
+/**
+ * Get the first Arbitrum block number that corresponds to a given L1 block.
+ * Falls back to binary search if l2BlockRangeForL1 reverts.
+ */
+export async function getFirstArbBlockForL1Block(
+  provider: Provider,
+  l1BlockNumber: number
+): Promise<number> {
+  const nodeInterface = NodeInterface__factory.connect(
+    NODE_INTERFACE_ADDRESS,
+    provider
+  )
+  try {
+    return (
+      await nodeInterface.l2BlockRangeForL1(l1BlockNumber)
+    ).firstBlock.toNumber()
+  } catch (e) {
+    const blockNum = (
+      await getBlockRangesForL1Block({
+        arbitrumProvider: provider as JsonRpcProvider,
+        forL1Block: l1BlockNumber,
+        allowGreater: true,
+      })
+    )[0]
+    if (!blockNum) throw e
+    return blockNum
+  }
 }
 
 type GetFirstBlockForL1BlockProps = {


### PR DESCRIPTION
Fix three bugs in InboxTools that break force inclusion when the parent chain is an Arbitrum chain (L3 / Orbit scenario):                                                                                              
                                                                                                                                                                                                                         
  - maxTimeVariation decoder error: decodeFunctionResult()[0] stripped named properties from the result, causing maxTimeVariation.delayBlocks to be undefined and throwing Cannot read properties of undefined (reading  
  'toNumber'). Removed the [0] index.                                                                                                                                                                                    
  - Wrong block number in forceInclude: Passed the Arb block number to the contract, but block.number in Solidity on Arbitrum returns the L1 block number, so l1BlockAndTime[0] + delayBlocks >=          
  block.number was always true, permanently reverting with ForceIncludeBlockTooSoon. Now fetches the corresponding L1 block number via ArbitrumProvider.getBlock() when the parent chain is Arbitrum.                    
  - findFirstBlockBelow recursion bug: First iteration correctly mapped L1 → L2 block number, but recursive calls passed the L2 block number back into l2BlockRangeForL1() as if it were an L1 block number, causing
  lookup failures. Introduced a separate l2BlockNumber variable so recursion always uses the original L1 block number.  