### PR TITLE
fix: allowlist serialize-javascript DoS advisory (GHSA-qj8w-gfj5-8c6v)

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -130,6 +130,12 @@
     // from: mocha>serialize-javascript
     // from: hardhat>mocha>serialize-javascript
     "GHSA-5c6j-r48x-rmvq",
+    // https://github.com/advisories/GHSA-qj8w-gfj5-8c6v
+    // serialize-javascript CPU exhaustion DoS via crafted array-like objects
+    // Fix requires serialize-javascript >=7.0.5, but all 7.x releases require Node >=20; dev-only mocha dep
+    // from: mocha>serialize-javascript
+    // from: hardhat>mocha>serialize-javascript
+    "GHSA-qj8w-gfj5-8c6v",
 
     // ethers transitive dependencies (dev-only)
     // https://github.com/advisories/GHSA-378v-28hj-76wf


### PR DESCRIPTION
## Summary
- Allowlists new `serialize-javascript` advisory [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) (CPU exhaustion DoS via crafted array-like objects, moderate)
- Dev-only dependency via `mocha>serialize-javascript` and `hardhat>mocha>serialize-javascript`
- Fix requires `serialize-javascript >=7.0.5` which needs Node >=20; same constraint as existing allowlisted advisory for this package

## Test plan
- [x] `npm run audit:ci` passes locally