### PR TITLE
chore: bump version to 4.1.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arbitrum/sdk",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Typescript library client-side interactions with Arbitrum",
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bumps the `@arbitrum/sdk` package minor version from `4.0.5` to `4.1.0`.