### PR TITLE
chore: allowlist 4 new undici advisories in audit-ci

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -164,6 +164,26 @@
     // undici CRLF injection via `upgrade` option
     // from: hardhat>undici
     "GHSA-4992-7rv2-5pvq",
+    // https://github.com/advisories/GHSA-vxpw-j846-p89q
+    // undici WebSocket client DoS via fragment count bypass
+    // Fix requires undici >=6.27.0 but hardhat depends on undici 5.x; dev-only
+    // from: hardhat>undici
+    "GHSA-vxpw-j846-p89q",
+    // https://github.com/advisories/GHSA-p88m-4jfj-68fv
+    // undici HTTP header injection via Set-Cookie percent-decoding
+    // Fix requires undici >=6.27.0 but hardhat depends on undici 5.x; dev-only
+    // from: hardhat>undici
+    "GHSA-p88m-4jfj-68fv",
+    // https://github.com/advisories/GHSA-35p6-xmwp-9g52
+    // undici HTTP response queue poisoning via keep-alive socket reuse
+    // Fix requires undici >=6.27.0 but hardhat depends on undici 5.x; dev-only
+    // from: hardhat>undici
+    "GHSA-35p6-xmwp-9g52",
+    // https://github.com/advisories/GHSA-g8m3-5g58-fq7m
+    // undici Set-Cookie SameSite attribute downgrade via permissive substring matching
+    // Fix requires undici >=6.27.0 but hardhat depends on undici 5.x; dev-only
+    // from: hardhat>undici
+    "GHSA-g8m3-5g58-fq7m",
 
     // https://github.com/advisories/GHSA-w5hq-g745-h8pq
     // uuid v3/v5/v6 missing bounds check on caller-provided buffers


### PR DESCRIPTION
## What

Adds 4 newly-published `undici` advisories (all `<6.27.0`) to the audit-ci allowlist:

- `GHSA-vxpw-j846-p89q` (high) — WebSocket client DoS via fragment count bypass
- `GHSA-p88m-4jfj-68fv` (moderate) — HTTP header injection via Set-Cookie percent-decoding
- `GHSA-35p6-xmwp-9g52` (low) — HTTP response queue poisoning via keep-alive socket reuse
- `GHSA-g8m3-5g58-fq7m` (low) — Set-Cookie SameSite downgrade via permissive substring matching

## Why

All four reach the tree only as dev-only transitive deps via `hardhat>undici` (pinned to 5.x). The fixes require `undici >=6.27.0`, which hardhat does not yet permit. This matches the existing handling of the other `hardhat>undici` advisories already in the allowlist.

These started failing the `Audit on Node.js v24` check once the advisories propagated to the npm audit endpoint.